### PR TITLE
docs(cookbook): hot-module-replacement.md, migration-vuex.md, testing.md and options-api.md translation

### DIFF
--- a/cookbook/hot-module-replacement.md
+++ b/cookbook/hot-module-replacement.md
@@ -1,6 +1,6 @@
 # HMR (Sustitución de módulos en caliente)
 
-Pinia soporta el reemplazo Hot Module para que puedas editar tus almacenes e interactuar con ellas directamente en tu aplicación sin recargar la página, permitiéndote mantener el estado existente, añadir o incluso eliminar estados, acciones y getters.
+Pinia soporta el reemplazo de módulos en caliente para que puedas editar tus almacenes e interactuar con ellas directamente en tu aplicación sin recargar la página, permitiéndote mantener el estado existente, añadir o incluso eliminar estados, acciones y getters.
 
 Por el momento, sólo [Vite](https://vitejs.dev/) está oficialmente soportado, pero cualquier bundler que implemente la especificación `import.meta.hot` debería funcionar (por ejemplo, [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) parece utilizar `import.meta.webpackHot` en lugar de `import.meta.hot`).
 Debes añadir este fragmento de código junto a cualquier declaración de almacén. Digamos que tienes tres almacenes: `auth.js`, `cart.js`, y `chat.js`, tendrás que añadir (y adaptar) esto después de la creación de la _deficinición del almacén_:

--- a/cookbook/hot-module-replacement.md
+++ b/cookbook/hot-module-replacement.md
@@ -1,22 +1,19 @@
-# Aún no está traducido...
----
+# HMR (Sustitución de módulos en caliente)
 
-# HMR (Hot Module Replacement)
+Pinia soporta el reemplazo Hot Module para que puedas editar tus almacenes e interactuar con ellas directamente en tu aplicación sin recargar la página, permitiéndote mantener el estado existente, añadir o incluso eliminar estados, acciones y getters.
 
-Pinia supports Hot Module replacement so you can edit your stores and interact with them directly in your app without reloading the page, allowing you to keep the existing state, add, or even remove state, actions, and getters.
-
-At the moment, only [Vite](https://vitejs.dev/) is officially supported but any bundler implementing the `import.meta.hot` spec should work (e.g. [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) seems to use `import.meta.webpackHot` instead of `import.meta.hot`).
-You need to add this snippet of code next to any store declaration. Let's say you have three stores: `auth.js`, `cart.js`, and `chat.js`, you will have to add (and adapt) this after the creation of the _store definition_:
+Por el momento, sólo [Vite](https://vitejs.dev/) está oficialmente soportado, pero cualquier bundler que implemente la especificación `import.meta.hot` debería funcionar (por ejemplo, [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) parece utilizar `import.meta.webpackHot` en lugar de `import.meta.hot`).
+Debes añadir este fragmento de código junto a cualquier declaración de almacén. Digamos que tienes tres almacenes: `auth.js`, `cart.js`, y `chat.js`, tendrás que añadir (y adaptar) esto después de la creación de la _deficinición del almacén_:
 
 ```js
 // auth.js
 import { defineStore, acceptHMRUpdate } from 'pinia'
 
 const useAuth = defineStore('auth', {
-  // options...
+  // opciones...
 })
 
-// make sure to pass the right store definition, `useAuth` in this case.
+// asegúrate de pasar la definición del almacén correcto, `useAuth` en este caso.
 if (import.meta.hot) {
   import.meta.hot.accept(acceptHMRUpdate(useAuth, import.meta.hot))
 }

--- a/cookbook/migration-vuex.md
+++ b/cookbook/migration-vuex.md
@@ -8,21 +8,21 @@ Primero, siga la [Guía de introducción](../getting-started.md) para instalar P
 
 ## Reestructuración de Módulos a Almacén
 
-Vuex tiene el concepto de un único almacén con múltiples _módulos_. Opcionalmente, estos módulos pueden tener espacios de nombres e incluso anidarse entre sí.
+Vuex tiene el concepto de un único almacén con múltiples _módulos_. Opcionalmente, estos módulos pueden tener namespaced e incluso anidarse entre sí.
 
-La forma más fácil de hacer la transición de ese concepto para usar con Pinia es que cada módulo que usó anteriormente ahora es un _almacén_. Cada almacén requiere de un `id` que es similar a un espacio de nombres en Vuex. Esto significa que cada almacén tiene un espacio de nombres por diseño. Los módulos anidados también pueden convertirse cada uno en su propia almacén. Los almacenes que dependen unas de otras simplemente importarán el otro almacén.
+La forma más fácil de hacer la transición de ese concepto para usar con Pinia es que cada módulo que usó anteriormente ahora es un _almacén_. Cada almacén requiere de un `id` que es similar a un namespace en Vuex. Esto significa que cada almacén tiene un namespaced por diseño. Los módulos anidados también pueden convertirse cada uno en su propia almacén. Los almacenes que dependen unas de otras simplemente importarán el otro almacén.
 
 La forma en que elijas reestructurar tus módulos Vuex en los almacenes Pinia depende completamente de tí, pero aquí hay una sugerencia:
 
 ```bash
-# Ejemplo de Vuex (asumiendo módulos con espacio de nombres)
+# Ejemplo de Vuex (asumiendo módulos con namespaced)
 src
 └── store
     ├── index.js           # Inicializa Vuex, importa módulos
     └── modules
-        ├── module1.js     # namespace 'module1'
+        ├── module1.js     # 'module1' namespace
         └── nested
-            ├── index.js   # namespace 'nested', importa 'module2' y 'module3'
+            ├── index.js   # 'nested' namespace, importa 'module2' y 'module3'
             ├── module2.js # 'nested/module2' namespace
             └── module3.js # 'nested/module3' namespace
 
@@ -36,7 +36,7 @@ src
     └── nested.js         # 'nested' id
 ```
 
-Esto crea una estructura plana para los almacenes, pero también conserva el espacio de nombres anterior con `id`s equivalentes. Si tenía algunos estados/getters/acciones/mutaciones en la raíz del almacén (en el archivo `store/index.js` de Vuex), es posible que desees crear otro almacén llamada algo así como `root` que contenga toda esa información.
+Esto crea una estructura plana para los almacenes, pero también conserva el namespacing anterior con `id`s equivalentes. Si tenía algunos estados/getters/acciones/mutaciones en la raíz del almacén (en el archivo `store/index.js` de Vuex), es posible que desees crear otro almacén llamada algo así como `root` que contenga toda esa información.
 
 El directorio para Pinia se llama generalmente `stores` en lugar de `store`. Esto es para enfatizar que Pinia utiliza múltiples almacenes, en lugar de un único almacén en Vuex.
 
@@ -47,7 +47,7 @@ Para proyectos grandes es posible que desee hacer esta conversión módulo por m
 Aquí hay un ejemplo completo del antes y el después de convertir un módulo Vuex a un almacén Pinia, ver más abajo para una guía paso a paso. El ejemplo Pinia utiliza un almacén de opciones como la estructura es más similar a Vuex:
 
 ```ts
-// Módulo Vuex en el espacio de nombres 'auth/user'
+// Módulo Vuex en el 'auth/user' namespace
 import { Module } from 'vuex'
 import { api } from '@/api'
 import { RootState } from '@/types' // si se utiliza una definición de tipo Vuex
@@ -76,7 +76,7 @@ const storeModule: Module<State, RootState> = {
         fullName: getters.fullName,
         // leer el estado de otro módulo llamado `auth`
         ...rootState.auth.preferences,
-        // leer un captador de un módulo con espacio de nombres llamado `email` anidado bajo `auth`
+        // leer un getter de un módulo con un namespaced llamado `email` anidado bajo `auth`
         ...rootGetters['auth/email'].details
       }
     }
@@ -174,7 +174,7 @@ export const useAuthUserStore = defineStore('authUser', {
 
 Desglosemos lo anterior en pasos:
 
-1. Añade un `id` requerido para el almacén, puedes mantenerlo igual que el espacio de nombre anterior. También se recomienda asegurarse de que el `id` está en _camelCase_ ya que hace que sea más fácil de usar con `mapStores()`.
+1. Añade un `id` requerido para el almacén, puedes mantenerlo igual que el namespace anterior. También se recomienda asegurarse de que el `id` está en _camelCase_ ya que hace que sea más fácil de usar con `mapStores()`.
 2. Convertir `state` en una función si aún no lo era
 3. Convertir `getters`
     1. Elimina cualquier getter que devuelva estado con el mismo nombre (por ejemplo, `firstName: (state) => state.firstName`), no son necesarios ya que puedes acceder a cualquier estado directamente desde la instancia del almacén

--- a/cookbook/migration-vuex.md
+++ b/cookbook/migration-vuex.md
@@ -194,7 +194,7 @@ Como puedes ver, la mayor parte de su código puede reutilizarse. La seguridad t
 
 Ahora que tu módulo Vuex se ha convertido en un almacén de Pinia, cualquier componente u otro archivo que utilice ese módulo necesita ser actualizado también.
 
-Si estabas usando asistentes `map` de Vuex, merece la pena mirar el [Utilización sin la guía setup()](./options-api.md) ya que la mayoría de esos asistentes pueden reutilizarse.
+Si estabas usando asistentes `map` de Vuex, merece la pena mirar la [Utilización sin la guía setup()](./options-api.md) ya que la mayoría de esos asistentes pueden reutilizarse.
 
 Si estabas usando `useStore` entonces importa el nuevo almacén directamente y accede al estado en él. Por ejemplo:
 

--- a/cookbook/migration-vuex.md
+++ b/cookbook/migration-vuex.md
@@ -10,7 +10,7 @@ Primero, siga la [Guía de introducción](../getting-started.md) para instalar P
 
 Vuex tiene el concepto de un único almacén con múltiples _módulos_. Opcionalmente, estos módulos pueden tener namespaced e incluso anidarse entre sí.
 
-La forma más fácil de hacer la transición de ese concepto para usar con Pinia es que cada módulo que usó anteriormente ahora es un _almacén_. Cada almacén requiere de un `id` que es similar a un namespace en Vuex. Esto significa que cada almacén tiene un namespaced por diseño. Los módulos anidados también pueden convertirse cada uno en su propia almacén. Los almacenes que dependen unas de otras simplemente importarán el otro almacén.
+La forma más fácil de hacer la transición de ese concepto para usar con Pinia es que cada módulo que usó anteriormente ahora es un _almacén_. Cada almacén requiere de un `id` que es similar a un namespace en Vuex. Esto significa que cada almacén tiene un namespaced por diseño. Los módulos anidados también pueden convertirse cada uno en su propio almacén. Los almacenes que dependen unos de otros simplemente importarán el otro almacén.
 
 La forma en que elijas reestructurar tus módulos Vuex en los almacenes Pinia depende completamente de tí, pero aquí hay una sugerencia:
 

--- a/cookbook/options-api.md
+++ b/cookbook/options-api.md
@@ -1,24 +1,21 @@
-# Aún no está traducido...
----
+# Utilización sin `setup()`.
 
-# Usage without `setup()`
-
-Pinia can be used even if you are not using the composition API (if you are using Vue <2.7, you still need to install the `@vue/composition-api` plugin though). While we recommend you give the Composition API a try and learn it, it might not be the time for you and your team yet, you might be in the process of migrating an application, or any other reason. There are a few functions:
+Pinia puede usarse incluso si no estás usando la API de composición (si estás usando Vue <2.7, todavía necesitas instalar el plugin `@vue/composition-api`). Aunque te recomendamos que pruebes la API de composición y la aprendas, puede que aún no sea el momento para ti y tu equipo, puede que estés en proceso de migrar una aplicación, o cualquier otra razón. Hay algunas funciones:
 
 - [mapStores](#giving-access-to-the-whole-store)
 - [mapState](../core-concepts/state.md#usage-with-the-options-api)
 - [mapWritableState](../core-concepts/state.md#modifiable-state)
-- ⚠️ [mapGetters](../core-concepts/getters.md#without-setup) (just for migration convenience, use `mapState()` instead)
+- ⚠️ [mapGetters](../core-concepts/getters.md#without-setup) (sólo para facilitar la migración, utiliza `mapState()` en su lugar)
 - [mapActions](../core-concepts/actions.md#without-setup)
 
-## Giving access to the whole store
+## Dando acceso a todo el almacén
 
-If you need to access pretty much everything from the store, it might be too much to map every single property of the store... Instead you can get access to the whole store with `mapStores()`:
+Si necesitas acceder a casi todo desde el almacén, puede que sea demasiado mapear cada una de las propiedades del almacén... En su lugar, puedes acceder a todo el almacén con `mapStores()`:
 
 ```js
 import { mapStores } from 'pinia'
 
-// given two stores with the following ids
+// dados dos almacenes con los siguientes ids
 const useUserStore = defineStore('user', {
   // ...
 })
@@ -28,14 +25,14 @@ const useCartStore = defineStore('cart', {
 
 export default {
   computed: {
-    // note we are not passing an array, just one store after the other
-    // each store will be accessible as its id + 'Store'
+    // ten en cuenta que no estamos pasando un array, sólo un almacén después de la otra
+    // cada almacén será accesible como su id + 'Store'
     ...mapStores(useCartStore, useUserStore)
   },
 
   methods: {
     async buyStuff() {
-      // use them anywhere!
+      // ¡usalos en cualquier lugar!
       if (this.userStore.isAuthenticated()) {
         await this.cartStore.buy()
         this.$router.push('/purchased')
@@ -45,36 +42,36 @@ export default {
 }
 ```
 
-By default, Pinia will add the `"Store"` suffix to the `id` of each store. You can customize this behavior by calling the `setMapStoreSuffix()`:
+Por defecto, Pinia añadirá el sufijo `"Store"` al `id` de cada almacén. Puedes personalizar este comportamiento llamando a `setMapStoreSuffix()`:
 
 ```js
 import { createPinia, setMapStoreSuffix } from 'pinia'
 
-// completely remove the suffix: this.user, this.cart
+// eliminar completamente el sufijo: this.user, this.cart
 setMapStoreSuffix('')
-// this.user_store, this.cart_store (it's okay, I won't judge you)
+// this.user_store, this.cart_store (está bien, no te juzgaré)
 setMapStoreSuffix('_store')
 export const pinia = createPinia()
 ```
 
 ## TypeScript
 
-By default, all map helpers support autocompletion and you don't need to do anything. If you call `setMapStoreSuffix()` to change the `"Store"` suffix, you will need to also add it somewhere in a TS file or your `global.d.ts` file. The most convenient place would be the same place where you call `setMapStoreSuffix()`:
+Por defecto, todos los helpers de mapas soportan el autocompletado y no necesitas hacer nada. Si llamas a `setMapStoreSuffix()` para cambiar el sufijo `"Store"`, tendrás que añadirlo también en algún lugar de un fichero TS o de su fichero `global.d.ts`. El lugar más conveniente sería el mismo lugar donde se llama a `setMapStoreSuffix()`:
 
 ```ts
 import { createPinia, setMapStoreSuffix } from 'pinia'
 
-setMapStoreSuffix('') // completely remove the suffix
+setMapStoreSuffix('') // eliminar completamente el sufijo
 export const pinia = createPinia()
 
 declare module 'pinia' {
   export interface MapStoresCustomization {
-    // set it to the same value as above
+    // Ajústalo al mismo valor que el anterior
     suffix: ''
   }
 }
 ```
 
 :::warning
-If you are using a TypeScript declaration file (like `global.d.ts`), make sure to `import 'pinia'` at the top of it to expose all existing types.
+Si estás usando un archivo de declaración TypeScript (como `global.d.ts`), asegúrate de `importar 'pinia'` al principio del mismo para exponer todos los tipos existentes.
 :::

--- a/cookbook/options-api.md
+++ b/cookbook/options-api.md
@@ -25,7 +25,7 @@ const useCartStore = defineStore('cart', {
 
 export default {
   computed: {
-    // ten en cuenta que no estamos pasando un array, sólo un almacén después de la otra
+    // ten en cuenta que no estamos pasando un array, sólo un almacén después de la otro
     // cada almacén será accesible como su id + 'Store'
     ...mapStores(useCartStore, useUserStore)
   },

--- a/cookbook/options-api.md
+++ b/cookbook/options-api.md
@@ -2,7 +2,7 @@
 
 Pinia puede usarse incluso si no estás usando la API de composición (si estás usando Vue <2.7, todavía necesitas instalar el plugin `@vue/composition-api`). Aunque te recomendamos que pruebes la API de composición y la aprendas, puede que aún no sea el momento para ti y tu equipo, puede que estés en proceso de migrar una aplicación, o cualquier otra razón. Hay algunas funciones:
 
-- [mapStores](#giving-access-to-the-whole-store)
+- [mapStores](#dando-acceso-a-todo-el-almacen)
 - [mapState](../core-concepts/state.md#usage-with-the-options-api)
 - [mapWritableState](../core-concepts/state.md#modifiable-state)
 - ⚠️ [mapGetters](../core-concepts/getters.md#without-setup) (sólo para facilitar la migración, utiliza `mapState()` en su lugar)

--- a/cookbook/testing.md
+++ b/cookbook/testing.md
@@ -1,6 +1,6 @@
-# Almacenes de prueba
+# Probar almacenes
 
-Los almacenes, por su diseño, se utilizarán en muchos lugares y pueden hacer que las pruebas sean mucho más difíciles de lo que deberían. Afortunadamente, esto no tiene por qué ser así. Tenemos tener cuidado de tres cosas al probar almacenes:
+Los almacenes, por su diseño, se utilizarán en muchos lugares y pueden hacer que las pruebas sean mucho más difíciles de lo que deberían. Afortunadamente, esto no tiene por qué ser así. Tenemos que tener cuidado de tres cosas al probar almacenes:
 
 - La instancia `pinia`: Los almacenes no pueden funcionar sin ella
 - `actions`: La mayoría de las veces contienen la lógica más compleja del almacén. ¿No sería bueno si pudieran burlarse de ellos por defecto?
@@ -8,7 +8,7 @@ Los almacenes, por su diseño, se utilizarán en muchos lugares y pueden hacer q
 
 Dependiendo de qué o cómo se realicen las pruebas, debemos ocuparnos de estos tres aspectos de forma diferente:
 
-- [Almacenes de prueba](#almacenes-de-prueba)
+- [Probar almacenes](#probar-almacenes)
   - [Pruebas unitarias de un almacén](#pruebas-unitarias-de-un-almacen)
   - [Componentes de las pruebas unitarias](#componentes-de-las-pruebas-unitarias)
     - [Estado inicial](#estado-inicial)
@@ -101,7 +101,7 @@ store.name = 'my new name'
 store.$patch({ name: 'new name' })
 expect(store.name).toBe('new name')
 
-// están bloqueadas por defecto, lo que significa que no ejecutan su código por defecto.
+// las acciones están bloqueadas por defecto, lo que significa que no ejecutan su código por defecto.
 // Consulta más abajo para personalizar este comportamiento.
 store.someAction()
 
@@ -124,7 +124,7 @@ const useCounterStore = defineStore('counter', {
 })
 ```
 
-Dado que el almacén se llama _"contador"_, es necesario añadir un objeto coincidente a `initialState`:
+Dado que el almacén se llama _"counter"_, es necesario añadir un objeto coincidente a `initialState`:
 
 ```ts
 // en alguna parte de tu prueba
@@ -133,7 +133,7 @@ const wrapper = mount(Counter, {
     plugins: [
       createTestingPinia({
         initialState: {
-          counter: { n: 20 }, // iniciar el contador en 20 en lugar de 0
+          counter: { n: 20 }, // iniciar el counter en 20 en lugar de 0
         },
       }),
     ],
@@ -168,7 +168,7 @@ expect(store.someAction).toHaveBeenCalledTimes(1)
 
 ### Especificación de la función createSpy
 
-Cuando se utiliza Jest, o vitest con `globals: true`, `createTestingPinia` automáticamente stubs acciones utilizando la función espía basada en el marco de prueba existente (`jest.fn` o `vitest.fn`). Si estás utilizando un framework diferente, tendrás que proporcionar una opción [createSpy](https://pinia.vuejs.org/api/interfaces/pinia_testing.TestingOptions.html#createspy):
+Cuando se utiliza Jest, o vitest con `globals: true`, `createTestingPinia` automáticamente las acciones stubs usan la funciones espía en base a framework de pruebas existente (`jest.fn` o `vitest.fn`). Si estás utilizando un framework diferente, tendrás que proporcionar una opción [createSpy](https://pinia.vuejs.org/api/interfaces/pinia_testing.TestingOptions.html#createspy):
 
 ```js
 import sinon from 'sinon'

--- a/cookbook/testing.md
+++ b/cookbook/testing.md
@@ -1,30 +1,27 @@
-# Aún no está traducido...
----
+# Almacenes de prueba
 
-# Testing stores
+Los almacenes, por su diseño, se utilizarán en muchos lugares y pueden hacer que las pruebas sean mucho más difíciles de lo que deberían. Afortunadamente, esto no tiene por qué ser así. Tenemos tener cuidado de tres cosas al probar almacenes:
 
-Stores will, by design, be used at many places and can make testing much harder than it should be. Fortunately, this doesn't have to be the case. We need to take care of three things when testing stores:
+- La instancia `pinia`: Los almacenes no pueden funcionar sin ella
+- `actions`: La mayoría de las veces contienen la lógica más compleja del almacén. ¿No sería bueno si pudieran burlarse de ellos por defecto?
+- Plugins: Si dependes de plugins, tendrás que instalarlos también para las pruebas
 
-- The `pinia` instance: Stores cannot work without it
-- `actions`: most of the time, they contain the most complex logic of our stores. Wouldn't it be nice if they were mocked by default?
-- Plugins: If you rely on plugins, you will have to install them for tests too
+Dependiendo de qué o cómo se realicen las pruebas, debemos ocuparnos de estos tres aspectos de forma diferente:
 
-Depending on what or how you are testing, we need to take care of these three differently:
-
-- [Testing stores](#testing-stores)
-  - [Unit testing a store](#unit-testing-a-store)
-  - [Unit testing components](#unit-testing-components)
-    - [Initial State](#initial-state)
-    - [Customizing behavior of actions](#customizing-behavior-of-actions)
-    - [Specifying the createSpy function](#specifying-the-createspy-function)
-    - [Mocking getters](#mocking-getters)
+- [Almacenes de prueba](#testing-stores)
+  - [Pruebas unitarias de un almacén](#unit-testing-a-store)
+  - [Componentes de las pruebas unitarias](#unit-testing-components)
+    - [Estado inicial](#initial-state)
+    - [Personalizar el comportamiento de las acciones](#customizing-behavior-of-actions)
+    - [Especificación de la función createSpy](#specifying-the-createspy-function)
+    - [Simuladores getters](#mocking-getters)
     - [Pinia Plugins](#pinia-plugins)
-  - [E2E tests](#e2e-tests)
-  - [Unit test components (Vue 2)](#unit-test-components-vue-2)
+  - [Pruebas E2E](#e2e-tests)
+  - [Componentes de pruebas unitarias (Vue 2)](#unit-test-components-vue-2)
 
-## Unit testing a store
+## Pruebas unitarias de un almacén
 
-To unit test a store, the most important part is creating a `pinia` instance:
+Para probar unitariamente un almacén, la parte más importante es crear una instancia de `pinia`:
 
 ```js
 // stores/counter.spec.ts
@@ -33,8 +30,8 @@ import { useCounter } from '../src/stores/counter'
 
 describe('Counter Store', () => {
   beforeEach(() => {
-    // creates a fresh pinia and make it active so it's automatically picked
-    // up by any useStore() call without having to pass it to it:
+    // crea una Pinia nueva y la activa para que se elija automáticamente
+    // por cualquier llamada a useStore() sin tener que pasarla:
     // `useStore(pinia)`
     setActivePinia(createPinia())
   })
@@ -54,16 +51,16 @@ describe('Counter Store', () => {
 })
 ```
 
-If you have any store plugins, there is one important thing to know: **plugins won't be used until `pinia` is installed in an App**. This can be solved by creating an empty App or a fake one:
+Si tienes algún plugin del almacén, hay una cosa importante que debes saber: **los plugins no se utilizarán hasta que `pinia` esté instalado en una aplicación**. Esto se puede solucionar creando una aplicación vacía o una falsa:
 
 ```js
 import { setActivePinia, createPinia } from 'pinia'
 import { createApp } from 'vue'
 import { somePlugin } from '../src/stores/plugin'
 
-// same code as above...
+// mismo código que arriba...
 
-// you don't need to create one app per test
+// no es necesario crear una aplicación por prueba
 const app = createApp({})
 beforeEach(() => {
   const pinia = createPinia().use(somePlugin)
@@ -72,22 +69,22 @@ beforeEach(() => {
 })
 ```
 
-## Unit testing components
+## Componentes de las pruebas unitarias
 
-This can be achieved with `createTestingPinia()`, which returns a pinia instance designed to help unit tests components.
+Esto se puede lograr con `createTestingPinia()`, que devuelve una instancia pinia diseñada para ayudar a los componentes de pruebas unitarias.
 
-Start by installing `@pinia/testing`:
+Empieza instalando `@pinia/testing`:
 
 ```shell
 npm i -D @pinia/testing
 ```
 
-And make sure to create a testing pinia in your tests when mounting a component:
+Y asegúrese de crear una pinia de prueba en sus pruebas cuando monte un componente:
 
 ```js
 import { mount } from '@vue/test-utils'
 import { createTestingPinia } from '@pinia/testing'
-// import any store you want to interact with in tests
+// importar cualquier almacén con la que desees interactuar en las pruebas
 import { useSomeStore } from '@/stores/myStore'
 
 const wrapper = mount(Counter, {
@@ -96,27 +93,27 @@ const wrapper = mount(Counter, {
   },
 })
 
-const store = useSomeStore() // uses the testing pinia!
+const store = useSomeStore() // ¡utiliza la pinia de pruebas!
 
-// state can be directly manipulated
+// el estado puede manipularse directamente
 store.name = 'my new name'
-// can also be done through patch
+// también se puede hacer a través de patch
 store.$patch({ name: 'new name' })
 expect(store.name).toBe('new name')
 
-// actions are stubbed by default, meaning they don't execute their code by default.
-// See below to customize this behavior.
+// están bloqueadas por defecto, lo que significa que no ejecutan su código por defecto.
+// Consulta más abajo para personalizar este comportamiento.
 store.someAction()
 
 expect(store.someAction).toHaveBeenCalledTimes(1)
 expect(store.someAction).toHaveBeenLastCalledWith()
 ```
 
-Please note that if you are using Vue 2, `@vue/test-utils` requires a [slightly different configuration](#unit-test-components-vue-2).
+Ten en cuenta que si utilizas Vue 2, `@vue/test-utils` requiere una [configuración ligeramente diferente](#unit-test-components-vue-2).
 
-### Initial State
+### Estado inicial
 
-You can set the initial state of **all of your stores** when creating a testing pinia by passing an `initialState` object. This object will be used by the testing pinia to _patch_ stores when they are created. Let's say you want to initialize the state of this store:
+Puede establecer el estado inicial de **todos sus almacenes** al crear una pinia de pruebas pasando un objeto `initialState`. Este objeto será utilizado por la pinia de pruebas para _parchear_ los almacenes cuando sean creados. Digamos que quieres inicializar el estado de este almacén:
 
 ```ts
 import { defineStore } from 'pinia'
@@ -127,31 +124,31 @@ const useCounterStore = defineStore('counter', {
 })
 ```
 
-Since the store is named _"counter"_, you need to add a matching object to `initialState`:
+Dado que el almacén se llama _"contador"_, es necesario añadir un objeto coincidente a `initialState`:
 
 ```ts
-// somewhere in your test
+// en alguna parte de tu prueba
 const wrapper = mount(Counter, {
   global: {
     plugins: [
       createTestingPinia({
         initialState: {
-          counter: { n: 20 }, // start the counter at 20 instead of 0
+          counter: { n: 20 }, // iniciar el contador en 20 en lugar de 0
         },
       }),
     ],
   },
 })
 
-const store = useSomeStore() // uses the testing pinia!
+const store = useSomeStore() // ¡utiliza la pinia de pruebas!
 store.n // 20
 ```
 
-### Customizing behavior of actions
+### Personalizar el comportamiento de las acciones
 
-`createTestingPinia` stubs out all store actions unless told otherwise. This allows you to test your components and stores separately.
+`createTestingPinia`  extrae todas las acciones del almacén a menos que se indique lo contrario. Esto le permite probar tus componentes y almacenes por separado.
 
-If you want to revert this behavior and normally execute your actions during tests, specify `stubActions: false` when calling `createTestingPinia`:
+Si deseas revertir este comportamiento y ejecutar normalmente sus acciones durante las pruebas, especifique `stubActions: false` al llamar a `createTestingPinia`:
 
 ```js
 const wrapper = mount(Counter, {
@@ -162,30 +159,30 @@ const wrapper = mount(Counter, {
 
 const store = useSomeStore()
 
-// Now this call WILL execute the implementation defined by the store
+// Ahora esta llamada EJECUTARÁ la implementación definida por el almacén
 store.someAction()
 
-// ...but it's still wrapped with a spy, so you can inspect calls
+// ...pero sigue envuelto con un espía, así que puedes inspeccionar las llamadas
 expect(store.someAction).toHaveBeenCalledTimes(1)
 ```
 
-### Specifying the createSpy function
+### Especificación de la función createSpy
 
-When using Jest, or vitest with `globals: true`, `createTestingPinia` automatically stubs actions using the spy function based on the existing test framework (`jest.fn` or `vitest.fn`). If you are using a different framework, you'll need to provide a [createSpy](https://pinia.vuejs.org/api/interfaces/pinia_testing.TestingOptions.html#createspy) option:
+Cuando se utiliza Jest, o vitest con `globals: true`, `createTestingPinia` automáticamente stubs acciones utilizando la función espía basada en el marco de prueba existente (`jest.fn` o `vitest.fn`). Si estás utilizando un framework diferente, tendrás que proporcionar una opción [createSpy](https://pinia.vuejs.org/api/interfaces/pinia_testing.TestingOptions.html#createspy):
 
 ```js
 import sinon from 'sinon'
 
 createTestingPinia({
-  createSpy: sinon.spy, // use sinon's spy to wrap actions
+  createSpy: sinon.spy, // usa el espía de sinon para envolver acciones
 })
 ```
 
-You can find more examples in [the tests of the testing package](https://github.com/vuejs/pinia/blob/v2/packages/testing/src/testing.spec.ts).
+Puede encontrar más ejemplos en [las pruebas del paquete de pruebas](https://github.com/vuejs/pinia/blob/v2/packages/testing/src/testing.spec.ts).
 
-### Mocking getters
+### Simuladores getters
 
-By default, any getter will be computed like regular usage but you can manually force a value by setting the getter to anything you want:
+Por defecto, cualquier getter se calculará como un uso normal, pero puedes forzar manualmente un valor estableciendo el getter a lo que quieras:
 
 ```ts
 import { defineStore } from 'pinia'
@@ -201,23 +198,23 @@ const useCounter = defineStore('counter', {
 const pinia = createTestingPinia()
 const counter = useCounter(pinia)
 
-counter.double = 3 // 🪄 getters are writable only in tests
+counter.double = 3 // 🪄 los getters sólo se pueden escribir en las pruebas
 
-// set to undefined to reset the default behavior
-// @ts-expect-error: usually it's a number
+// establecer a undefined para restablecer el comportamiento por defecto
+// @ts-expect-error: generalmente es un número
 counter.double = undefined
 counter.double // 2 (=1 x 2)
 ```
 
-### Pinia Plugins
+### Plugins Pinia
 
-If you have any pinia plugins, make sure to pass them when calling `createTestingPinia()` so they are properly applied. **Do not add them with `testingPinia.use(MyPlugin)`** like you would do with a regular pinia:
+Si tienes algún plugin de pinia, asegúrate de pasarlo cuando llames a `createTestingPinia()` para que se apliquen correctamente. **No los añadas con `testingPinia.use(MyPlugin)`** como lo harías con una pinia normal:
 
 ```js
 import { createTestingPinia } from '@pinia/testing'
 import { somePlugin } from '../src/stores/plugin'
 
-// inside some test
+// dentro de alguna prueba
 const wrapper = mount(Counter, {
   global: {
     plugins: [
@@ -230,13 +227,13 @@ const wrapper = mount(Counter, {
 })
 ```
 
-## E2E tests
+## Pruebas E2E
 
-When it comes to pinia, you don't need to change anything for e2e tests, that's the whole point of e2e tests! You could maybe test HTTP requests, but that's way beyond the scope of this guide 😄.
+Cuando se trata de pinia, no necesitas cambiar nada para las pruebas e2e, ¡ese es todo el punto de las pruebas e2e! Tal vez podría probar las peticiones HTTP, pero eso está mucho más allá del alcance de esta guía 😄.
 
-## Unit test components (Vue 2)
+## Componentes de pruebas unitarias (Vue 2)
 
-When using [Vue Test Utils 1](https://v1.test-utils.vuejs.org/), install Pinia on a `localVue`:
+Cuando utilices [Vue Test Utils 1](https://v1.test-utils.vuejs.org/), instala Pinia en un `localVue`:
 
 ```js
 import { PiniaVuePlugin } from 'pinia'
@@ -251,5 +248,5 @@ const wrapper = mount(Counter, {
   pinia: createTestingPinia(),
 })
 
-const store = useSomeStore() // uses the testing pinia!
+const store = useSomeStore() // ¡utiliza la pinia de pruebas!
 ```

--- a/cookbook/testing.md
+++ b/cookbook/testing.md
@@ -8,16 +8,16 @@ Los almacenes, por su diseño, se utilizarán en muchos lugares y pueden hacer q
 
 Dependiendo de qué o cómo se realicen las pruebas, debemos ocuparnos de estos tres aspectos de forma diferente:
 
-- [Almacenes de prueba](#testing-stores)
-  - [Pruebas unitarias de un almacén](#unit-testing-a-store)
-  - [Componentes de las pruebas unitarias](#unit-testing-components)
-    - [Estado inicial](#initial-state)
+- [Almacenes de prueba](#almacenes-de-prueba)
+  - [Pruebas unitarias de un almacén](#pruebas-unitarias-de-un-almacen)
+  - [Componentes de las pruebas unitarias](#componentes-de-las-pruebas-unitarias)
+    - [Estado inicial](#estado-inicial)
     - [Personalizar el comportamiento de las acciones](#customizing-behavior-of-actions)
-    - [Especificación de la función createSpy](#specifying-the-createspy-function)
-    - [Simuladores getters](#mocking-getters)
+    - [Especificación de la función createSpy](#especificacion-de-la-funcion-createSpy)
+    - [Simuladores getters](#simuladores-getters)
     - [Pinia Plugins](#pinia-plugins)
-  - [Pruebas E2E](#e2e-tests)
-  - [Componentes de pruebas unitarias (Vue 2)](#unit-test-components-vue-2)
+  - [Pruebas E2E](#pruebas-e2e)
+  - [Componentes de pruebas unitarias (Vue 2)](#componentes-de-pruebas-unitarias-vue-2)
 
 ## Pruebas unitarias de un almacén
 
@@ -109,7 +109,7 @@ expect(store.someAction).toHaveBeenCalledTimes(1)
 expect(store.someAction).toHaveBeenLastCalledWith()
 ```
 
-Ten en cuenta que si utilizas Vue 2, `@vue/test-utils` requiere una [configuración ligeramente diferente](#unit-test-components-vue-2).
+Ten en cuenta que si utilizas Vue 2, `@vue/test-utils` requiere una [configuración ligeramente diferente](#componentes-de-pruebas-unitarias-vue-2).
 
 ### Estado inicial
 
@@ -206,7 +206,7 @@ counter.double = undefined
 counter.double // 2 (=1 x 2)
 ```
 
-### Plugins Pinia
+### Pinia Plugins
 
 Si tienes algún plugin de pinia, asegúrate de pasarlo cuando llames a `createTestingPinia()` para que se apliquen correctamente. **No los añadas con `testingPinia.use(MyPlugin)`** como lo harías con una pinia normal:
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Feature :sparkles:
- [ ] Code style update (formatting, renaming) :art:
- [ ] Refactoring (no functional changes, no api changes) :recycle:
- [X] Documentation content changes :memo:
- [ ] Other :zap:

## What is the new behavior?

- Adding new translation to hot-module-replacement.md, testing.md and options-api.md translation
- Update translation to migration-vuex.md (_namespace_,  _namespaced_, _namespacing_ words, the translation was not applied because it is easy to understand and does not have a developer-friendly translation)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
