### PR TITLE
fix: use english anchors

### DIFF
--- a/cookbook/hot-module-replacement.md
+++ b/cookbook/hot-module-replacement.md
@@ -1,9 +1,9 @@
-# HMR (Sustitución de módulos en caliente)
+# HMR (Sustitución de módulos en caliente) {#hmr-hot-module-replacement}
 
 Pinia soporta el reemplazo de módulos en caliente para que puedas editar tus almacenes e interactuar con ellas directamente en tu aplicación sin recargar la página, permitiéndote mantener el estado existente, añadir o incluso eliminar estados, acciones y getters.
 
 Por el momento, sólo [Vite](https://vitejs.dev/) está oficialmente soportado, pero cualquier bundler que implemente la especificación `import.meta.hot` debería funcionar (por ejemplo, [webpack](https://webpack.js.org/api/module-variables/#importmetawebpackhot) parece utilizar `import.meta.webpackHot` en lugar de `import.meta.hot`).
-Debes añadir este fragmento de código junto a cualquier declaración de almacén. Digamos que tienes tres almacenes: `auth.js`, `cart.js`, y `chat.js`, tendrás que añadir (y adaptar) esto después de la creación de la _deficinición del almacén_:
+Debes añadir este fragmento de código junto a cualquier declaración de almacén. Digamos que tienes tres almacenes: `auth.js`, `cart.js`, y `chat.js`, tendrás que añadir (y adaptar) esto después de la creación de la _definición del almacén_:
 
 ```js
 // auth.js

--- a/cookbook/index.md
+++ b/cookbook/index.md
@@ -1,4 +1,4 @@
-# Manual
+# Manual {#cookbook}
 
 - [Migración desde Vuex ≤4](./migration-vuex.md): Una guía de migración para convertir proyectos Vuex ≤4.
 - [Sustitución de módulos en caliente](./hot-module-replacement.md): Cómo activar el reemplazo de módulos activos y mejorar la experiencia del desarrollador.

--- a/cookbook/migration-vuex.md
+++ b/cookbook/migration-vuex.md
@@ -1,12 +1,12 @@
-# Migración desde Vuex ≤4
+# Migración desde Vuex ≤4 {#migrating-from-vuex-≤4}
 
 Aunque la estructura de los almacenes de Vuex y Pinia es diferente, gran parte de la lógica puede ser reutilizada. Esta guía sirve para ayudarte a través del proceso y señalar algunos líos comunes que pueden aparecer.
 
-## Preparación
+## Preparación {#preparation}
 
 Primero, siga la [Guía de introducción](../getting-started.md) para instalar Pinia.
 
-## Reestructuración de Módulos a Almacén
+## Reestructuración de Módulos a Almacén {#restructuring-modules-to-stores}
 
 Vuex tiene el concepto de un único almacén con múltiples _módulos_. Opcionalmente, estos módulos pueden tener namespaced e incluso anidarse entre sí.
 
@@ -42,7 +42,7 @@ El directorio para Pinia se llama generalmente `stores` en lugar de `store`. Est
 
 Para proyectos grandes es posible que desee hacer esta conversión módulo por módulo en lugar de convertir todo a la vez. En realidad se puede mezclar Pinia y Vuex juntos durante la migración por lo que este enfoque también puede funcionar y es otra razón para nombrar el directorio Pinia `stores` en su lugar.
 
-## Conversión de un solo módulo
+## Conversión de un solo módulo {#converting-a-single-module}
 
 Aquí hay un ejemplo completo del antes y el después de convertir un módulo Vuex a un almacén Pinia, ver más abajo para una guía paso a paso. El ejemplo Pinia utiliza un almacén de opciones como la estructura es más similar a Vuex:
 
@@ -190,7 +190,7 @@ Desglosemos lo anterior en pasos:
 
 Como puedes ver, la mayor parte de su código puede reutilizarse. La seguridad tipográfica también debería ayudarte a identificar qué hay que cambiar si se te escapa algo.
 
-## Uso dentro de los componentes
+## Uso dentro de los componentes {#usage-inside-components}
 
 Ahora que tu módulo Vuex se ha convertido en un almacén de Pinia, cualquier componente u otro archivo que utilice ese módulo necesita ser actualizado también.
 
@@ -240,7 +240,7 @@ export default defineComponent({
 })
 ```
 
-## Uso fuera de los componentes
+## Uso fuera de los componentes {#usage-outside-components}
 
 Actualizar el uso fuera de los componentes debería ser sencillo siempre y cuando tengas cuidado de _no usar un almacén fuera de las funciones_. Aquí hay un ejemplo de uso del almacén en un guardia de navegación Vue Router:
 
@@ -268,19 +268,19 @@ router.beforeEach((to, from, next) => {
 
 Más información [aquí](../core-concepts/outside-component-usage.md).
 
-## Uso avanzado de Vuex
+## Uso avanzado de Vuex {#advanced-vuex-usage}
 
 En el caso de que tu almacén Vuex utiliza algunas de las características más avanzadas que ofrece, aquí tienes una guía sobre cómo lograr lo mismo en Pinia. Algunos de estos puntos ya están cubiertos en [este resumen comparativo](../introduction.md#comparison-with-vuex-3-x-4-x).
 
-### Módulos dinámicos
+### Módulos dinámicos {#dynamic-modules}
 
 No es necesario registrar módulos dinámicamente en Pinia. Los almacenes son dinámicos por diseño y sólo se registran cuando se necesitan. Si un almacén nunca se utiliza, nunca será "registrado".
 
-### Sustitución de módulos en caliente
+### Sustitución de módulos en caliente {#hot-module-replacement}
 
 Sustitución de módulos en caliente también es compatible, pero tendrá que ser sustituido, consulte la [Guía Sustitución de módulos en caliente](./hot-module-replacement.md).
 
-### Plugins
+### Plugins {#plugins}
 
 Si utilizas un plugin público de Vuex, compruebe si existe una alternativa Pinia. Si no, tendrás que escribir el tuyo propio o evaluar si el plugin sigue siendo necesario.
 

--- a/cookbook/options-api.md
+++ b/cookbook/options-api.md
@@ -1,4 +1,4 @@
-# Utilización sin `setup()`.
+# Uso sin `setup()`. {#usage-without-setup}
 
 Pinia puede usarse incluso si no estás usando la API de composición (si estás usando Vue <2.7, todavía necesitas instalar el plugin `@vue/composition-api`). Aunque te recomendamos que pruebes la API de composición y la aprendas, puede que aún no sea el momento para ti y tu equipo, puede que estés en proceso de migrar una aplicación, o cualquier otra razón. Hay algunas funciones:
 
@@ -8,7 +8,7 @@ Pinia puede usarse incluso si no estás usando la API de composición (si estás
 - ⚠️ [mapGetters](../core-concepts/getters.md#without-setup) (sólo para facilitar la migración, utiliza `mapState()` en su lugar)
 - [mapActions](../core-concepts/actions.md#without-setup)
 
-## Dando acceso a todo el almacén
+## Dando acceso a todo el almacén {#giving-access-to-the-whole-store}
 
 Si necesitas acceder a casi todo desde el almacén, puede que sea demasiado mapear cada una de las propiedades del almacén... En su lugar, puedes acceder a todo el almacén con `mapStores()`:
 
@@ -54,7 +54,7 @@ setMapStoreSuffix('_store')
 export const pinia = createPinia()
 ```
 
-## TypeScript
+## TypeScript {#typescript}
 
 Por defecto, todos los helpers de mapas soportan el autocompletado y no necesitas hacer nada. Si llamas a `setMapStoreSuffix()` para cambiar el sufijo `"Store"`, tendrás que añadirlo también en algún lugar de un fichero TS o de su fichero `global.d.ts`. El lugar más conveniente sería el mismo lugar donde se llama a `setMapStoreSuffix()`:
 

--- a/cookbook/testing.md
+++ b/cookbook/testing.md
@@ -1,4 +1,4 @@
-# Probar almacenes
+# Probar almacenes {#testing-stores}
 
 Los almacenes, por su diseño, se utilizarán en muchos lugares y pueden hacer que las pruebas sean mucho más difíciles de lo que deberían. Afortunadamente, esto no tiene por qué ser así. Tenemos que tener cuidado de tres cosas al probar almacenes:
 
@@ -19,7 +19,7 @@ Dependiendo de qué o cómo se realicen las pruebas, debemos ocuparnos de estos 
   - [Pruebas E2E](#pruebas-e2e)
   - [Componentes de pruebas unitarias (Vue 2)](#componentes-de-pruebas-unitarias-vue-2)
 
-## Pruebas unitarias de un almacén
+## Pruebas unitarias de un almacén {#unit-testing-a-store}
 
 Para probar unitariamente un almacén, la parte más importante es crear una instancia de `pinia`:
 
@@ -69,7 +69,7 @@ beforeEach(() => {
 })
 ```
 
-## Componentes de las pruebas unitarias
+## Componentes de las pruebas unitarias {#unit-testing-components}
 
 Esto se puede lograr con `createTestingPinia()`, que devuelve una instancia pinia diseñada para ayudar a los componentes de pruebas unitarias.
 
@@ -111,7 +111,7 @@ expect(store.someAction).toHaveBeenLastCalledWith()
 
 Ten en cuenta que si utilizas Vue 2, `@vue/test-utils` requiere una [configuración ligeramente diferente](#componentes-de-pruebas-unitarias-vue-2).
 
-### Estado inicial
+### Estado inicial {#initial-state}
 
 Puede establecer el estado inicial de **todos sus almacenes** al crear una pinia de pruebas pasando un objeto `initialState`. Este objeto será utilizado por la pinia de pruebas para _parchear_ los almacenes cuando sean creados. Digamos que quieres inicializar el estado de este almacén:
 
@@ -144,7 +144,7 @@ const store = useSomeStore() // ¡utiliza la pinia de pruebas!
 store.n // 20
 ```
 
-### Personalizar el comportamiento de las acciones
+### Personalizar el comportamiento de las acciones {#customizing-behavior-of-actions}
 
 `createTestingPinia`  extrae todas las acciones del almacén a menos que se indique lo contrario. Esto le permite probar tus componentes y almacenes por separado.
 
@@ -166,7 +166,7 @@ store.someAction()
 expect(store.someAction).toHaveBeenCalledTimes(1)
 ```
 
-### Especificación de la función createSpy
+### Especificación de la función createSpy {#specifying-the-createspy-function}
 
 Cuando se utiliza Jest, o vitest con `globals: true`, `createTestingPinia` automáticamente las acciones stubs usan la funciones espía en base a framework de pruebas existente (`jest.fn` o `vitest.fn`). Si estás utilizando un framework diferente, tendrás que proporcionar una opción [createSpy](https://pinia.vuejs.org/api/interfaces/pinia_testing.TestingOptions.html#createspy):
 
@@ -180,7 +180,7 @@ createTestingPinia({
 
 Puede encontrar más ejemplos en [las pruebas del paquete de pruebas](https://github.com/vuejs/pinia/blob/v2/packages/testing/src/testing.spec.ts).
 
-### Simuladores getters
+### Simular getters {#mocking-getters}
 
 Por defecto, cualquier getter se calculará como un uso normal, pero puedes forzar manualmente un valor estableciendo el getter a lo que quieras:
 
@@ -206,7 +206,7 @@ counter.double = undefined
 counter.double // 2 (=1 x 2)
 ```
 
-### Pinia Plugins
+### Plugins de Pinia {#pinia-plugins}
 
 Si tienes algún plugin de pinia, asegúrate de pasarlo cuando llames a `createTestingPinia()` para que se apliquen correctamente. **No los añadas con `testingPinia.use(MyPlugin)`** como lo harías con una pinia normal:
 
@@ -227,11 +227,11 @@ const wrapper = mount(Counter, {
 })
 ```
 
-## Pruebas E2E
+## Pruebas E2E {#e2e-tests}
 
 Cuando se trata de pinia, no necesitas cambiar nada para las pruebas e2e, ¡ese es todo el punto de las pruebas e2e! Tal vez podría probar las peticiones HTTP, pero eso está mucho más allá del alcance de esta guía 😄.
 
-## Componentes de pruebas unitarias (Vue 2)
+## Componentes de pruebas unitarias (Vue 2) {#unit-test-components-vue-2}
 
 Cuando utilices [Vue Test Utils 1](https://v1.test-utils.vuejs.org/), instala Pinia en un `localVue`:
 

--- a/core-concepts/index.md
+++ b/core-concepts/index.md
@@ -1,4 +1,4 @@
-# Definir un Almacén
+# Definir un Almacén {#defining-a-store}
 
 <VueSchoolLink
   href="https://vueschool.io/lessons/define-your-first-pinia-store"
@@ -24,7 +24,7 @@ Este _nombre_, también conocido como _id_, es obligatorio y es usado por Pinia 
 
 `defineStore()` acepta dos valores distintos para su segundo parámetro: una función Setup o un objeto de opciones.
 
-## Almacenes de Opciones
+## Almacenes de Opciones {#option-stores}
 
 Tal y como se hace en la API de opciones de Vue, podemos pasar un objeto de opciones con las propiedades `state`, `actions` y `getters`.
 
@@ -46,7 +46,7 @@ Puedes pensar en `state` como los `datos` del almacén, `getters` como las propi
 
 Los almacenes de opciones deberían sentirse como algo intuitivo y simple para empezar.
 
-## Almacenes con Setup
+## Almacenes con Setup {#setup-stores}
 
 También hay otra posible sintaxis para definir los almacenes. Es parecida a la [función setup](https://vuejs.org/api/composition-api-setup.html) de la API de composición de Vue, podemos pasarle una función que defina propiedades reactivas y métodos, y que devuelva un objecto con las propiedades y métodos que queremos exponer.
 
@@ -69,13 +69,13 @@ En los _almacenes con setup_:
 - `computed()` se convierte en `getters`
 - `function()` se convierte en `actions`
 
-Los almacenes con setup ofrecen mucha más flexibilidad que los [almacenes de opciones](#almacenes-de-opciones) dado que puedes crear observadores en un almacén y usar libremente cualquier [composable](https://vuejs.org/guide/reusability/composables.html#composables). Sin embargo, ten en mente que usar composables puede traer más complejidad cuando se usa [SSR](../cookbook/composables.md).
+Los almacenes con setup ofrecen mucha más flexibilidad que los [almacenes de opciones](#option-stores) dado que puedes crear observadores en un almacén y usar libremente cualquier [composable](https://vuejs.org/guide/reusability/composables.html#composables). Sin embargo, ten en mente que usar composables puede traer más complejidad cuando se usa [SSR](../cookbook/composables.md).
 
-## ¿Qué sintaxis debería usar?
+## ¿Qué sintaxis debería usar? {#what-syntax-should-i-pick}
 
-Al igual que con las [API de composición y API de opciones de Vue](https://vuejs.org/guide/introduction.html#which-to-choose), quédate con la que te sientas más cómodo. Si no estás seguro prueba primero los [almacenes de opciones](#almacenes-de-opciones).
+Al igual que con las [API de composición y API de opciones de Vue](https://vuejs.org/guide/introduction.html#which-to-choose), quédate con la que te sientas más cómodo. Si no estás seguro prueba primero los [almacenes de opciones](#option-stores).
 
-## Usando el almacén
+## Usando el almacén {#using-the-store}
 
 Estamos _definiendo_ un almacén porque hasta que no se llame a `use...Store()` dentro de `setup()` este no se creará.
 

--- a/core-concepts/state.md
+++ b/core-concepts/state.md
@@ -1,4 +1,4 @@
-# Estado
+# Estado {#state}
 
 <VueSchoolLink
   href="https://vueschool.io/lessons/access-state-from-a-pinia-store"
@@ -29,7 +29,7 @@ export const useStore = defineStore('storeId', {
 Si estás usando Vue 2, los datos creados en `state` seguirán las mismas reglas que el `data` en una instancia de Vue, por eso el objeto estado tiene que ser plano y necesitas llamar a `Vue.set()` cuando **añadas nuevas** propiedades a él. **Mira también: [Vue#data](https://v2.vuejs.org/v2/api/#data)**.
 :::
 
-## TypeScript
+## TypeScript {#typescript}
 
 No necesitas hacer mucho para poder hacer tu estado compatible con TS: asegúrate de que [`strict`](https://www.typescriptlang.org/tsconfig#strict) o, al menos, [`noImplicitThis`](https://www.typescriptlang.org/tsconfig#noImplicitThis) estén habilitados y !Pinia deducirá los tipos de tu estado automáticamente! Sin embargo, hay pocas veces donde deberás proporcionárselo manualmente con algún casting.
 
@@ -73,7 +73,7 @@ interface UserInfo {
 }
 ```
 
-## Acceder al `estado`
+## Acceder al `estado` {#accessing-the-state}
 
 Por defecto, puedes leer y escribir en el estado directamente accediendo a él a través la instancia del `almacén`:
 
@@ -85,7 +85,7 @@ store.count++
 
 Cabe aclarar que no puedes añadir una nueva propiedad al estado **si no está definida en `state()`**, tiene que contener el estado inicial, por ejemplo: no podemos hacer `store.secondCount = 2` si `secondCount` no está definido en `state()`.
 
-## Restablecer el estado
+## Restablecer el estado {#resetting-the-state}
 
 Puedes restablecer el estado a su valor inicial llamando al método `$reset()` del almacén:
 
@@ -95,7 +95,7 @@ const store = useStore()
 store.$reset()
 ```
 
-### Uso con la API de Opciones
+### Uso con la API de Opciones {#usage-with-the-options-api}
 
 <VueSchoolLink
   href="https://vueschool.io/lessons/access-pinia-state-in-the-options-api"
@@ -142,7 +142,7 @@ export default {
 }
 ```
 
-#### Estado modificable
+#### Estado modificable {#modifiable-state}
 
 Si quieres poder escribir en estas propiedades de estado (por ejemplo, si tienes un formulario), puedes utilizar `mapWritableState()` en su lugar. Ten en cuenta que no puedes pasar una función como con `mapState()`:
 
@@ -168,7 +168,7 @@ export default {
 No necesitas `mapWritableState()` para colecciones como arrays a no ser que estés sustituyendo el array al completo con `cartItems = []`, `mapState()` te sigue permitiendo llamar métodos en tus colecciones.
 :::
 
-## Mutar el estado
+## Mutar el estado {#mutating-the-state}
 
 Aparte de mutar directamente el almacén con `store.count++`, también puedes llamar al método `$patch`. Te permite aplicar múltiples cambios a la vez con un objeto `estado` parcial:
 
@@ -191,7 +191,7 @@ store.$patch((state) => {
 
 La principal diferencia aquí es que `$patch()` te permite agrupar multiples cambios en una sola entrada en las herramientas de desarrollo. Cabe aclarar que **ambas formas, cambios directo al `estado` y `$patch()` aparecen en las herramientas de desarrollo** y pueden ser movidas en el tiempo (aún no es posible en Vue 3).
 
-## Reemplazar el `estado`
+## Reemplazar el `estado` {#replacing-the-state}
 
 **No puedes reemplazar como tal** el estado de un almacén ya que rompería la reactividad. Pero puedes _parchearlo_:
 
@@ -208,7 +208,7 @@ También puedes **establecer el estado inicial** de toda tu aplicación con camb
 pinia.state.value = {}
 ```
 
-## Suscribirse al estado
+## Suscribirse al estado {#subscribing-to-the-state}
 
 Puedes observar el estado y sus cambios a través del método `$subscribe()` de un almacén, similar al [método subscribe](https://vuex.vuejs.org/api/#subscribe) de Vuex. Las ventajas de usar `$subscribe()` sobre un `watch()` común es que las _suscripciones_ se activarán solo después de los _parches_ (por ejemplo cuando usas la versión en función de lo anterior).
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,4 +1,4 @@
-## Instalación
+## Instalación {#installation}
 
 <VueMasteryLogoLink for="pinia-cheat-sheet">
 </VueMasteryLogoLink>
@@ -52,11 +52,11 @@ new Vue({
 
 Esto también añade soporte para las herramientas de desarrollo. En Vue 3 algunas características como volver para atrás y editar no están todavía disponibles porque vue-devtools no muestra las APIs necesarias aún pero las herramientas de desarrollo tienen muchas más características y la experiencia de desarrollo está a otro nivel. En Vue 2, Pinia usa la ya existente interfaz para Vuex (y por tanto no se pueden usar a la vez).
 
-## ¿Qué es un Almacén?
+## ¿Qué es un Almacén? {#what-is-a-store}
 
 Un almacén (como Pinia) es una entidad que contiene el estado y la lógica de negocio que no está vinculada al árbol de componentes. En otras palabras, **contiene el estado global**. Es como si fuese un componente que está siempre ahí y todos los demás pueden leerlo y escribirlo. Tiene **tres conceptos**, el [estado](./core-concepts/state.md), [getters](./core-concepts/getters.md) y [acciones](./core-concepts/actions.md) y es seguro afirmar que estos conceptos son equivalentes a `datos`, `propiedades computadas` y `métodos` de los componentes.
 
-## ¿Cuándo debería usar un Almacén?
+## ¿Cuándo debería usar un Almacén? {#when-should-i-use-a-store}
 
 Un almacén debería contener datos que pudiesen ser accesibles a lo largo de una aplicación. Esto incluye los datos que son usados en muchos sitios, como por ejemplo información del usuario que se está mostrando en la barra de navegación, así como datos que necesiten ser conservados entre páginas, como por ejemplo un formulario muy complejos con muchos pasos.
 

--- a/introduction.md
+++ b/introduction.md
@@ -1,4 +1,4 @@
-# Introducción
+# Introducción {#introduction}
 
 <VueSchoolLink
   href="https://vueschool.io/lessons/introduction-to-pinia"
@@ -7,7 +7,7 @@
 
 Pinia [comenzó](https://github.com/vuejs/pinia/commit/06aeef54e2cad66696063c62829dac74e15fd19e) como un experimento para rediseñar el como se vería un almacén de Vue con la [API de composición](https://github.com/vuejs/composition-api) allá por noviembre de 2019. Desde entonces, los principios básicos se han mantenido igual, pero Pinia funciona para Vue 2 y Vue 3 **y no es necesario hacer uso de la API de composición**. La API es igual para ambos excepto para _instalarlo_ y _SSR_, y esta documentación se enfoca en Vue 3 **con notas sobre Vue 2** cuando sea necesario ¡para que pueda ser leído por usuarios de Vue 2 y Vue 3!
 
-## ¿Por qué debería usar Pinia?
+## ¿Por qué debería usar Pinia? {#why-should-i-use-pinia}
 
 Pinia es una librería de almacenes para Vue que te permite compartir el estado entre los distintos componentes/páginas. Si estás familiarizado con la API de composición probablemente estarás pensando que ya puedes compartir un estado global con un simple `export const state = reactive({})`. Esto es cierto para aplicaciones de una sola página (SPA) pero **expone to aplicación a [vulnerabilidades de seguridad](https://vuejs.org/guide/scaling-up/ssr.html#cross-request-state-pollution)** si es renderizada en el lado del servidor. Pero incluso en aplicaciones de una sola página pequeñas obtienes mucho al usar Pinia:
 
@@ -25,7 +25,7 @@ Pinia es una librería de almacenes para Vue que te permite compartir el estado 
 <VueMasteryLogoLink for="pinia-cheat-sheet">
 </VueMasteryLogoLink>
 
-## Ejemplos básicos
+## Ejemplos básicos {#basic-example}
 
 Así es como se ve usar Pinia en términos de API (asegúrate de mirar el [Cómo Empezar](./getting-started.md) para instrucciones más detalladas). Tienes que empezar creando un almacén:
 
@@ -113,11 +113,11 @@ export default {
 
 Podrás encontrar más información sobre cada _map helper_ en los conceptos básicos.
 
-## Por qué _Pinia_
+## Por qué _Pinia_ {#why-pinia}
 
 Pinia (pronunciado `/piːnjʌ/`, como "peenya" en inglés) es la palabra más cercana a _piña_ válida para el nombre de un paquete. Una piña es en realidad un grupo de flores individuales que unen para crear una fruta. Es parecido a los almacenes, cada una se crea individualmente pero al final están todas conectadas. También es una deliciosa fruta tropical originaria de Sudamérica.
 
-## Un ejemplo más realista
+## Un ejemplo más realista {#a-more-realistic-example}
 
 Aquí tienes un ejemplo más complejo del API que estarás usando con Pinia **con tipos incluso en JavaScript**. Para algunas personas esto debería bastar para empezar sin continuar leyendo, pero recomendamos mirar el resto de la documentación o incluso saltarse este ejemplo y volver cuando se haya leído todos los _Conceptos Básicos_.
 
@@ -164,19 +164,19 @@ export const useTodos = defineStore('todos', {
 })
 ```
 
-## Comparación con Vuex
+## Comparación con Vuex {#comparison-with-vuex}
 
 Pinia comenzó como una aproximación de como sería la próxima versión de Vuex, incorporando muchas ideas de las discusiones del equipo principal para Vuex 5. Finalmente nos dimos cuenta que Pinia ya implementaba gran parte de lo que queríamos en Vuex 5 y se decidió convertirlo en la nueva recomendación en su lugar.
 
 Comparado con Vuex, Pinia proporciona una API más simple con menos decoraciones, ofrece API siguiendo el estilo de la API de composición y, lo más importante, tiene una sólida deducción de tipos cuando es usado con TypeScript.
 
-### RFCs
+### RFCs {#rfcs}
 
 Inicialmente Pinia no pasó por ningún proceso de RFC. He probado ideas basadas en mi experiencia desarrollando aplicaciones, leyendo el código de otras personas, trabajando para clientes que usan Pinia y respondiendo preguntas en Discord. Esto me permitió ofrecer una solución que funciona y está adaptada a una variedad de casos y tamaños de aplicaciones. A veces solía publicar y hacía que la librería evolucionase mientras mantenía su API central a la vez.
 
 Ahora que Pinia se ha convertido en la solución para manejar el estado por defecto está sujeto a los mismos procesos RFC del resto de librerías principales del ecosistema de Vue y su API ha entrado en un estado estable.
 
-### Comparación con Vuex 3.x/4.x
+### Comparación con Vuex 3.x/4.x {#comparison-with-vuex-3-x-4-x}
 
 > Vuex 3.x es Vuex para Vue 2 mientras que Vuex 4.x es para Vue 3
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Feature :sparkles:
- [ ] Code style update (formatting, renaming) :art:
- [ ] Refactoring (no functional changes, no api changes) :recycle:
- [ ] Documentation content changes :memo:
- [ ] Other :zap:

## What is the new behavior?

According to [this section in the Vue Community Translation Guidelines](https://github.com/vuejs-translations/guidelines/blob/main/README.md#retaining-original-anchors) is a good practice to keep the anchors in English to switch between documentation languages easier. With this PR it will be done and we will continue to do so in the next files.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
