### PR TITLE
fix(cookbook): migrating vuex anchor

### DIFF
--- a/.vitepress/locales/es.js
+++ b/.vitepress/locales/es.js
@@ -82,7 +82,7 @@ export default {
           ],
         },
         {
-          text: 'Cookbook',
+          text: 'Manual',
           link: '/cookbook/',
           children: [
             {

--- a/cookbook/migration-vuex.md
+++ b/cookbook/migration-vuex.md
@@ -1,4 +1,4 @@
-# Migración desde Vuex ≤4 {#migrating-from-vuex-≤4}
+# Migración desde Vuex ≤4 {#migrating-from-vuex-4}
 
 Aunque la estructura de los almacenes de Vuex y Pinia es diferente, gran parte de la lógica puede ser reutilizada. Esta guía sirve para ayudarte a través del proceso y señalar algunos líos comunes que pueden aparecer.
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Feature :sparkles:
- [ ] Code style update (formatting, renaming) :art:
- [ ] Refactoring (no functional changes, no api changes) :recycle:
- [X] Documentation content changes :memo:
- [ ] Other :zap:

## What is the new behavior?

Anchor from "Migración desde Vuex ≤4" fixed. Also translation of the word "cookbook" in the sidebar.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
