### PR TITLE
add: 'Idiomas' to navbar with zh and en

### DIFF
--- a/.vitepress/locales/en.js
+++ b/.vitepress/locales/en.js
@@ -1,0 +1,134 @@
+export default {
+  vitepressConfig: {
+    title: 'Pinia',
+    lang: 'en-US',
+    description: 'The Vue Store that you will enjoy using',
+  },
+  themeConfig: {
+    label: 'English',
+    selectText: 'Languages',
+    editLinkText: 'Suggest changes to this page',
+    lastUpdated: 'Last Updated',
+
+    nav: [
+      { text: 'Guide', link: '/introduction.html' },
+      { text: 'API', link: '/api/' },
+      // { text: 'Config', link: '/config/' },
+      // { text: 'Plugins', link: '/plugins/' },
+      {
+        text: 'Links',
+        items: [
+          {
+            text: 'Discussions',
+            link: 'https://github.com/vuejs/pinia/discussions',
+          },
+          {
+            text: 'Chat',
+            link: 'https://chat.vuejs.org',
+          },
+          {
+            text: 'Twitter',
+            link: 'https://twitter.com/posva',
+          },
+          {
+            text: 'Changelog',
+            link: 'https://github.com/vuejs/pinia/blob/v2/packages/pinia/CHANGELOG.md',
+          },
+        ],
+      },
+    ],
+
+    sidebar: {
+      '/api/': [
+        {
+          text: 'packages',
+          children: [
+            { text: 'pinia', link: '/api/modules/pinia.html' },
+            { text: '@pinia/nuxt', link: '/api/modules/pinia_nuxt.html' },
+            {
+              text: '@pinia/testing',
+              link: '/api/modules/pinia_testing.html',
+            },
+          ],
+        },
+      ],
+      // catch-all fallback
+      '/': [
+        {
+          text: 'Introduction',
+          children: [
+            {
+              text: 'What is Pinia?',
+              link: '/introduction.html',
+            },
+            {
+              text: 'Getting Started',
+              link: '/getting-started.html',
+            },
+          ],
+        },
+        {
+          text: 'Core Concepts',
+          children: [
+            { text: 'Defining a Store', link: '/core-concepts/' },
+            { text: 'State', link: '/core-concepts/state.html' },
+            { text: 'Getters', link: '/core-concepts/getters.html' },
+            { text: 'Actions', link: '/core-concepts/actions.html' },
+            { text: 'Plugins', link: '/core-concepts/plugins.html' },
+            {
+              text: 'Stores outside of components',
+              link: '/core-concepts/outside-component-usage.html',
+            },
+          ],
+        },
+        {
+          text: 'Server-Side Rendering (SSR)',
+          children: [
+            {
+              text: 'Vue and Vite',
+              link: '/ssr/',
+            },
+            {
+              text: 'Nuxt.js',
+              link: '/ssr/nuxt.html',
+            },
+          ],
+        },
+        {
+          text: 'Cookbook',
+          link: '/cookbook/',
+          children: [
+            {
+              text: 'Migration from Vuex ≤4',
+              link: '/cookbook/migration-vuex.html',
+            },
+            {
+              text: 'Hot Module Replacement',
+              link: '/cookbook/hot-module-replacement.html',
+            },
+            {
+              text: 'Testing',
+              link: '/cookbook/testing.html',
+            },
+            {
+              text: 'Usage without setup()',
+              link: '/cookbook/options-api.html',
+            },
+            {
+              text: 'Composing Stores',
+              link: '/cookbook/composing-stores.html',
+            },
+            {
+              text: 'Migration from v0/v1 to v2',
+              link: '/cookbook/migration-v1-v2.html',
+            },
+            {
+              text: 'Dealing with composables',
+              link: '/cookbook/composables.html',
+            },
+          ],
+        },
+      ],
+    },
+  },
+}

--- a/.vitepress/locales/index.js
+++ b/.vitepress/locales/index.js
@@ -1,10 +1,16 @@
 import es from './es.js'
+import en from './en.js'
+import zh from './zh.js'
 
 export default {
   vitepressConfig: {
-    '/': es.vitepressConfig,
+    '/en/': en.vitepressConfig, // It'll be '/' on prod
+    '/': es.vitepressConfig,    // It'll be '/es/' on prod
+    '/zh/': zh.vitepressConfig,
   },
   themeConfig: {
-    '/': es.themeConfig,
+    '/en/': en.themeConfig,     // It'll be '/' on prod
+    '/': es.themeConfig,        // It'll be '/es/' on prod
+    '/zh/': zh.themeConfig
   },
 }

--- a/.vitepress/locales/zh.js
+++ b/.vitepress/locales/zh.js
@@ -1,0 +1,133 @@
+export default {
+  vitepressConfig: {
+    title: 'Pinia',
+    lang: 'zh-CN',
+    description: '值得你喜欢的 Vue Store',
+  },
+  themeConfig: {
+    label: '简体中文',
+    selectText: '选择语言',
+    editLinkText: '对本页提出修改建议',
+    lastUpdated: '最后更新',
+
+    nav: [
+      { text: '指南', link: '/zh/introduction.html' },
+      { text: 'API', link: '/zh/api/' },
+      // { text: 'Config', link: '/config/' },
+      // { text: 'Plugins', link: '/plugins/' },
+      {
+        text: '相关链接',
+        items: [
+          {
+            text: '论坛',
+            link: 'https://github.com/vuejs/pinia/discussions',
+          },
+          {
+            text: '聊天室',
+            link: 'https://chat.vuejs.org',
+          },
+          {
+            text: 'Twitter',
+            link: 'https://twitter.com/posva',
+          },
+          {
+            text: '更新日志',
+            link: 'https://github.com/vuejs/pinia/blob/v2/packages/pinia/CHANGELOG.md',
+          },
+        ],
+      },
+    ],
+
+    sidebar: {
+      '/zh/api/': [
+        {
+          text: 'packages',
+          children: [
+            { text: 'pinia', link: '/zh/api/modules/pinia.html' },
+            { text: '@pinia/nuxt', link: '/zh/api/modules/pinia_nuxt.html' },
+            {
+              text: '@pinia/testing',
+              link: '/zh/api/modules/pinia_testing.html',
+            },
+          ],
+        },
+      ],
+      '/zh/': [
+        {
+          text: '介绍',
+          children: [
+            {
+              text: 'Pinia 是什么？',
+              link: '/zh/introduction.html',
+            },
+            {
+              text: '开始',
+              link: '/zh/getting-started.html',
+            },
+          ],
+        },
+        {
+          text: '核心概念',
+          children: [
+            { text: '定义 Store', link: '/zh/core-concepts/' },
+            { text: 'State', link: '/zh/core-concepts/state.html' },
+            { text: 'Getter', link: '/zh/core-concepts/getters.html' },
+            { text: 'Action', link: '/zh/core-concepts/actions.html' },
+            { text: '插件', link: '/zh/core-concepts/plugins.html' },
+            {
+              text: '组件外的 Store',
+              link: '/zh/core-concepts/outside-component-usage.html',
+            },
+          ],
+        },
+        {
+          text: '服务端渲染 (SSR)',
+          children: [
+            {
+              text: 'Vue 与 Vite',
+              link: '/zh/ssr/',
+            },
+            {
+              text: 'Nuxt.js',
+              link: '/zh/ssr/nuxt.html',
+            },
+          ],
+        },
+        {
+          text: '手册',
+          link: '/zh/cookbook/',
+          children: [
+            {
+              text: '从 Vuex ≤4 迁移',
+              link: '/zh/cookbook/migration-vuex.html',
+            },
+            {
+              text: '热更新',
+              link: '/zh/cookbook/hot-module-replacement.html',
+            },
+            {
+              text: '测试',
+              link: '/zh/cookbook/testing.html',
+            },
+            {
+              text: '不使用 setup() 的用法',
+              link: '/zh/cookbook/options-api.html',
+            },
+            {
+              text: '组合式 Stores',
+              link: '/zh/cookbook/composing-stores.html',
+            },
+            {
+              text: '从 v0/v1 迁移至 v2',
+              link: '/zh/cookbook/migration-v1-v2.html',
+            },
+            {
+              text: '处理组合式函数',
+              link: '/zh/cookbook/composables.html',
+            },
+          ],
+        },
+      ],
+    },
+  },
+}


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Feature :sparkles:
- [ ] Code style update (formatting, renaming) :art:
- [x] Refactoring (no functional changes, no api changes) :recycle:
- [ ] Documentation content changes :memo:
- [ ] Other :zap:

## What is the new behavior?

Add the en and zh languages to nav bar, for future implementation

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
