### PR TITLE
fix: parameters-type title typos

### DIFF
--- a/api/interfaces/pinia.DefineSetupStoreOptions.md
+++ b/api/interfaces/pinia.DefineSetupStoreOptions.md
@@ -16,7 +16,7 @@ Parámetro de opciones de `defineStore()` para almacenes de configuración. Pued
 
 [DefineStoreOptionsBase](pinia.DefineStoreOptionsBase.md).
 
-## Tipado de la declaración {#type-parameters}
+## Tipado de los parámetros {#type-parameters}
 
 | Nombre | Tipo |
 | :------ | :------ |

--- a/api/interfaces/pinia.DefineStoreOptions.md
+++ b/api/interfaces/pinia.DefineStoreOptions.md
@@ -16,7 +16,7 @@ Parámetro de opciones de `defineStore()` para almacenes de opciones. Puede exte
 
 [DefineStoreOptionsBase](pinia.DefineStoreOptionsBase.md).
 
-## Tipado de la declaración {#type-parameters}
+## Tipado de los parámetros {#type-parameters}
 
 | Nombre | Tipo |
 | :------ | :------ |

--- a/api/interfaces/pinia.DefineStoreOptionsBase.md
+++ b/api/interfaces/pinia.DefineStoreOptionsBase.md
@@ -13,7 +13,7 @@ sidebarDepth: 3
 Opciones pasadas a `defineStore()` que son comunes entre options y setup. 
 Extiende esta interfaz si deseas añadir opciones personalizadas a ambos tipos de almacenes.
 
-## Tipado de la declaración {#type-parameters}
+## Tipado de los parámetros {#type-parameters}
 
 | Nombre | Tipo |
 | :------ | :------ |


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Feature :sparkles:
- [ ] Code style update (formatting, renaming) :art:
- [x] Refactoring (no functional changes, no api changes) :recycle:
- [ ] Documentation content changes :memo:
- [ ] Other :zap:

## What is the new behavior?

Fix the `{#parameters-type}` titles from 'Tipado de la declaración' to 'Tipado de los parámetros'

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
