### PR TITLE
fix: 'API Documentation' -> 'Documentación de la API'

### DIFF
--- a/api/interfaces/pinia.DefineSetupStoreOptions.md
+++ b/api/interfaces/pinia.DefineSetupStoreOptions.md
@@ -4,7 +4,7 @@ editLinks: false
 sidebarDepth: 3
 ---
 
-[API Documentation](../index.md) / [pinia](../modules/pinia.md) / DefineSetupStoreOptions
+[Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / DefineSetupStoreOptions
 
 # Interfaz: DefineSetupStoreOptions<Id, S, G, A\> {#interface-definesetupstoreoptions-id-s-g-a}
 

--- a/api/interfaces/pinia.DefineStoreOptions.md
+++ b/api/interfaces/pinia.DefineStoreOptions.md
@@ -4,7 +4,7 @@ editLinks: false
 sidebarDepth: 3
 ---
 
-[API Documentation](../index.md) / [pinia](../modules/pinia.md) / DefineStoreOptions
+[Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / DefineStoreOptions
 
 # Interfaz: DefineStoreOptions<Id, S, G, A\> {#interface-definestoreoptions-id-s-g-a}
 

--- a/api/interfaces/pinia.DefineStoreOptionsBase.md
+++ b/api/interfaces/pinia.DefineStoreOptionsBase.md
@@ -4,7 +4,7 @@ editLinks: false
 sidebarDepth: 3
 ---
 
-[API Documentation](../index.md) / [pinia](../modules/pinia.md) / DefineStoreOptionsBase
+[Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / DefineStoreOptionsBase
 
 # Interfaz: DefineStoreOptionsBase<S, Store\> {#interface-definestoreoptionsbase-s-store}
 

--- a/api/interfaces/pinia._StoreOnActionListenerContext.md
+++ b/api/interfaces/pinia._StoreOnActionListenerContext.md
@@ -4,7 +4,7 @@ editLinks: false
 sidebarDepth: 3
 ---
 
-[API Documentation](../index.md) / [pinia](../modules/pinia.md) / \_StoreOnActionListenerContext
+[Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / \_StoreOnActionListenerContext
 
 # Interface: \_StoreOnActionListenerContext<Store, ActionName, A\>
 

--- a/api/interfaces/pinia._StoreWithState.md
+++ b/api/interfaces/pinia._StoreWithState.md
@@ -4,7 +4,7 @@ editLinks: false
 sidebarDepth: 3
 ---
 
-[API Documentation](../index.md) / [pinia](../modules/pinia.md) / \_StoreWithState
+[Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / \_StoreWithState
 
 # Interface: \_StoreWithState<Id, S, G, A\>
 

--- a/api/interfaces/pinia._SubscriptionCallbackMutationBase.md
+++ b/api/interfaces/pinia._SubscriptionCallbackMutationBase.md
@@ -4,7 +4,7 @@ editLinks: false
 sidebarDepth: 3
 ---
 
-[API Documentation](../index.md) / [pinia](../modules/pinia.md) / \_SubscriptionCallbackMutationBase
+[Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / \_SubscriptionCallbackMutationBase
 
 # Interface: \_SubscriptionCallbackMutationBase
 

--- a/api/interfaces/pinia_testing.TestingOptions.md
+++ b/api/interfaces/pinia_testing.TestingOptions.md
@@ -4,7 +4,7 @@ editLinks: false
 sidebarDepth: 3
 ---
 
-[API Documentation](../index.md) / [@pinia/testing](../modules/pinia_testing.md) / TestingOptions
+[Documentación de la API](../index.md) / [@pinia/testing](../modules/pinia_testing.md) / TestingOptions
 
 # Interfaz: TestingOptions {#interface-testingoptions}
 

--- a/api/interfaces/pinia_testing.TestingPinia.md
+++ b/api/interfaces/pinia_testing.TestingPinia.md
@@ -4,7 +4,7 @@ editLinks: false
 sidebarDepth: 3
 ---
 
-[API Documentation](../index.md) / [@pinia/testing](../modules/pinia_testing.md) / TestingPinia
+[Documentación de la API](../index.md) / [@pinia/testing](../modules/pinia_testing.md) / TestingPinia
 
 # Interfaz: TestingPinia {#interface-testingpinia}
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Feature :sparkles:
- [ ] Code style update (formatting, renaming) :art:
- [x] Refactoring (no functional changes, no api changes) :recycle:
- [ ] Documentation content changes :memo:
- [ ] Other :zap:

## What is the new behavior?

Change the 'API Documentation' link header to 'Documentación de la API'

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
