### PR TITLE
translate: 6 more files on `[api/interfaces]`

### DIFF
--- a/api/interfaces/pinia.SubscriptionCallbackMutationDirect.md
+++ b/api/interfaces/pinia.SubscriptionCallbackMutationDirect.md
@@ -26,7 +26,7 @@ newValue`.
 
 • **events**: `DebuggerEvent`
 
-🔴 DEV SOLAMENTE, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
+🔴 SOLO PARA DESARROLLO, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
 https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging y permite realizar un rastreo de las mutaciones 
 en devtools y plugins **sólo durante el desarrollo**.
 

--- a/api/interfaces/pinia.SubscriptionCallbackMutationDirect.md
+++ b/api/interfaces/pinia.SubscriptionCallbackMutationDirect.md
@@ -6,54 +6,54 @@ sidebarDepth: 3
 
 [API Documentation](../index.md) / [pinia](../modules/pinia.md) / SubscriptionCallbackMutationDirect
 
-# Interface: SubscriptionCallbackMutationDirect
+# Interfaz: SubscriptionCallbackMutationDirect {#interface-subscriptioncallbackmutationdirect}
 
 [pinia](../modules/pinia.md).SubscriptionCallbackMutationDirect
 
-Context passed to a subscription callback when directly mutating the state of
-a store with `store.someState = newValue` or `store.$state.someState =
+Contexto pasado a un callback de suscripción cuando se muta directamente el estado de 
+un almacén con `store.someState = newValue` o `store.$state.someState =
 newValue`.
 
-## Hierarchy
+##  Jerarquía {#hierarchy}
 
 - [`_SubscriptionCallbackMutationBase`](pinia._SubscriptionCallbackMutationBase.md)
 
   ↳ **`SubscriptionCallbackMutationDirect`**
 
-## Properties
+## Propiedades {#properties}
 
-### events
+### events {#events}
 
 • **events**: `DebuggerEvent`
 
-🔴 DEV ONLY, DO NOT use for production code. Different mutation calls. Comes from
-https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging and allows to track mutations in
-devtools and plugins **during development only**.
+🔴 DEV SOLAMENTE, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
+https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging y permite realizar un rastreo de las mutaciones 
+en devtools y plugins **sólo durante el desarrollo**.
 
-#### Overrides
+#### Sobrescribe {#overrides}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[events](pinia._SubscriptionCallbackMutationBase.md#events)
 
 ___
 
-### storeId
+### storeId {#storeid}
 
 • **storeId**: `string`
 
-`id` of the store doing the mutation.
+`id` del almacén que realiza la mutación.
 
-#### Inherited from
+#### Heredado de {#inherited-from}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[storeId](pinia._SubscriptionCallbackMutationBase.md#storeid)
 
 ___
 
-### type
+### type {#type}
 
 • **type**: [`direct`](../enums/pinia.MutationType.md#direct)
 
-Type of the mutation.
+Tipo de mutación.
 
-#### Overrides
+#### Sobrescribe {#overrides-1}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[type](pinia._SubscriptionCallbackMutationBase.md#type)

--- a/api/interfaces/pinia.SubscriptionCallbackMutationPatchFunction.md
+++ b/api/interfaces/pinia.SubscriptionCallbackMutationPatchFunction.md
@@ -6,53 +6,54 @@ sidebarDepth: 3
 
 [API Documentation](../index.md) / [pinia](../modules/pinia.md) / SubscriptionCallbackMutationPatchFunction
 
-# Interface: SubscriptionCallbackMutationPatchFunction
+# Interfaz: SubscriptionCallbackMutationPatchFunction {#interface-subscriptioncallbackmutationpatchfunction}
 
 [pinia](../modules/pinia.md).SubscriptionCallbackMutationPatchFunction
 
-Context passed to a subscription callback when `store.$patch()` is called
-with a function.
+Contexto pasado a un callback de suscripción cuando `store.$patch()` es llamado
+con una función.
 
-## Hierarchy
+## Jerarquía {#hierarchy}
 
 - [`_SubscriptionCallbackMutationBase`](pinia._SubscriptionCallbackMutationBase.md)
 
   ↳ **`SubscriptionCallbackMutationPatchFunction`**
 
-## Properties
+## Propiedades {#properties}
 
-### events
+### events {#events}
 
 • **events**: `DebuggerEvent`[]
 
-🔴 DEV ONLY, DO NOT use for production code. Different mutation calls. Comes from
-https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging and allows to track mutations in
-devtools and plugins **during development only**.
+🔴 DEV SOLAMENTE, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
+https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging y permite realizar un rastreo de las mutaciones 
+en devtools y plugins **sólo durante el desarrollo**.
 
-#### Overrides
+
+#### Sobrescribe {#overrides}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[events](pinia._SubscriptionCallbackMutationBase.md#events)
 
 ___
 
-### storeId
+### storeId {#storeid}
 
 • **storeId**: `string`
 
-`id` of the store doing the mutation.
+`id` del almacén que realiza la mutación.
 
-#### Inherited from
+#### Heredado de {#inherited-from}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[storeId](pinia._SubscriptionCallbackMutationBase.md#storeid)
 
 ___
 
-### type
+### type {#type}
 
 • **type**: [`patchFunction`](../enums/pinia.MutationType.md#patchfunction)
 
-Type of the mutation.
+Tipo de mutación.
 
-#### Overrides
+#### Sobrescribe {#overrides-1}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[type](pinia._SubscriptionCallbackMutationBase.md#type)

--- a/api/interfaces/pinia.SubscriptionCallbackMutationPatchFunction.md
+++ b/api/interfaces/pinia.SubscriptionCallbackMutationPatchFunction.md
@@ -25,7 +25,7 @@ con una función.
 
 • **events**: `DebuggerEvent`[]
 
-🔴 DEV SOLAMENTE, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
+🔴 SOLO PARA DESARROLLO, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
 https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging y permite realizar un rastreo de las mutaciones 
 en devtools y plugins **sólo durante el desarrollo**.
 

--- a/api/interfaces/pinia.SubscriptionCallbackMutationPatchObject.md
+++ b/api/interfaces/pinia.SubscriptionCallbackMutationPatchObject.md
@@ -31,7 +31,7 @@ con un objeto.
 
 • **events**: `DebuggerEvent`[]
 
-🔴 DEV SOLAMENTE, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
+🔴 SOLO PARA DESARROLLO, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
 https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging y permite realizar un rastreo de las mutaciones 
 en devtools y plugins **sólo durante el desarrollo**.
 

--- a/api/interfaces/pinia.SubscriptionCallbackMutationPatchObject.md
+++ b/api/interfaces/pinia.SubscriptionCallbackMutationPatchObject.md
@@ -6,67 +6,68 @@ sidebarDepth: 3
 
 [API Documentation](../index.md) / [pinia](../modules/pinia.md) / SubscriptionCallbackMutationPatchObject
 
-# Interface: SubscriptionCallbackMutationPatchObject<S\>
+# Interfaz: SubscriptionCallbackMutationPatchObject<S\> {#interface-subscriptioncallbackmutationpatchobject-s}
 
 [pinia](../modules/pinia.md).SubscriptionCallbackMutationPatchObject
 
-Context passed to a subscription callback when `store.$patch()` is called
-with an object.
+Contexto pasado a un callback de suscripción cuando `store.$patch()` es llamado
+con un objeto.
 
-## Type parameters
+## Tipado de los parámetros {#type-parameters}
 
-| Name |
+| Nombre |
 | :------ |
 | `S` |
 
-## Hierarchy
+## Jerarquía {#hierarchy}
 
 - [`_SubscriptionCallbackMutationBase`](pinia._SubscriptionCallbackMutationBase.md)
 
   ↳ **`SubscriptionCallbackMutationPatchObject`**
 
-## Properties
+## Propiedades {#properties}
 
-### events
+### events {#events}
 
 • **events**: `DebuggerEvent`[]
 
-🔴 DEV ONLY, DO NOT use for production code. Different mutation calls. Comes from
-https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging and allows to track mutations in
-devtools and plugins **during development only**.
+🔴 DEV SOLAMENTE, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
+https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging y permite realizar un rastreo de las mutaciones 
+en devtools y plugins **sólo durante el desarrollo**.
 
-#### Overrides
+
+#### Sobrescribe {#overrides}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[events](pinia._SubscriptionCallbackMutationBase.md#events)
 
 ___
 
-### payload
+### payload {#payload}
 
 • **payload**: [`_DeepPartial`](../modules/pinia.md#_deeppartial)<`S`\>
 
-Object passed to `store.$patch()`.
+Objeto pasado a `store.$patch()`.
 
 ___
 
-### storeId
+### storeId {#storeid}
 
 • **storeId**: `string`
 
-`id` of the store doing the mutation.
+`id` del almacén que realiza la mutación.
 
-#### Inherited from
+#### Heredado de {#inherited-from}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[storeId](pinia._SubscriptionCallbackMutationBase.md#storeid)
 
 ___
 
-### type
+### type {#type}
 
 • **type**: [`patchObject`](../enums/pinia.MutationType.md#patchobject)
 
-Type of the mutation.
+Tipo de mutación.
 
-#### Overrides
+#### Sobrescribe {#overrides-1}
 
 [_SubscriptionCallbackMutationBase](pinia._SubscriptionCallbackMutationBase.md).[type](pinia._SubscriptionCallbackMutationBase.md#type)

--- a/api/interfaces/pinia._StoreOnActionListenerContext.md
+++ b/api/interfaces/pinia._StoreOnActionListenerContext.md
@@ -6,88 +6,87 @@ sidebarDepth: 3
 
 [Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / \_StoreOnActionListenerContext
 
-# Interface: \_StoreOnActionListenerContext<Store, ActionName, A\>
+# Interfaz: \_StoreOnActionListenerContext<Store, ActionName, A\>  {#interface-storeonactionlistenercontext-store-actionname-a}
 
 [pinia](../modules/pinia.md)._StoreOnActionListenerContext
 
-Actual type for [StoreOnActionListenerContext](../modules/pinia.md#storeonactionlistenercontext). Exists for refactoring
-purposes. For internal use only.
-For internal use **only**
+Tipo real para [StoreOnActionListenerContext](../modules/pinia.md#storeonactionlistenercontext). Existe con fines de 
+refactorización. Sólo para uso interno. Sólo para uso **interno**
 
-## Type parameters
+## Tipado de los parámetros {#type-parameters}
 
-| Name | Type |
+| Nombre | Tipo |
 | :------ | :------ |
 | `Store` | `Store` |
-| `ActionName` | extends `string` |
+| `ActionName` | extiende `string` |
 | `A` | `A` |
 
-## Properties
+## Propiedades {#properties}
 
-### after
+### after {#after}
 
-• **after**: (`callback`: `A` extends `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? (`resolvedReturn`: [`_Awaited`](../modules/pinia.md#_awaited)<`ReturnType`<`A`[`ActionName`]\>\>) => `void` : () => `void`) => `void`
+• **after**: (`callback`: `A` extiende `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? (`resolvedReturn`: [`_Awaited`](../modules/pinia.md#_awaited)<`ReturnType`<`A`[`ActionName`]\>\>) => `void` : () => `void`) => `void`
 
-#### Type declaration
+#### Tipado de la declaración {#type-declaration}
 
 ▸ (`callback`): `void`
 
-Sets up a hook once the action is finished. It receives the return value
-of the action, if it's a Promise, it will be unwrapped.
+Establece un hook una vez finalizada la acción. Recibe el valor de retorno 
+de la acción, si es una Promise, se desenvolverá.
 
-##### Parameters
+##### Parámetros {#parameters}
 
-| Name | Type |
+| Nombre | Tipo |
 | :------ | :------ |
-| `callback` | `A` extends `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? (`resolvedReturn`: [`_Awaited`](../modules/pinia.md#_awaited)<`ReturnType`<`A`[`ActionName`]\>\>) => `void` : () => `void` |
+| `callback` | `A` extiende `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? (`resolvedReturn`: [`_Awaited`](../modules/pinia.md#_awaited)<`ReturnType`<`A`[`ActionName`]\>\>) => `void` : () => `void` |
 
-##### Returns
+##### Retorna {#returns}
 
 `void`
 
 ___
 
-### args
+### args {#args}
 
-• **args**: `A` extends `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? `Parameters`<`A`[`ActionName`]\> : `unknown`[]
+• **args**: `A` extiende `Record`<`ActionName`, [`_Method`](../modules/pinia.md#_method)\> ? `Parameters`<`A`[`ActionName`]\> : `unknown`[]
 
-Parameters passed to the action
+Parámetros pasados a la acción
 
 ___
 
-### name
+### name {#name}
 
 • **name**: `ActionName`
 
-Name of the action
+Nombre de la acción
 
 ___
 
-### onError
+### onError {#onerror}
 
 • **onError**: (`callback`: (`error`: `unknown`) => `void`) => `void`
 
-#### Type declaration
+#### Tipado de la declaración {#type-declaration-1}
 
 ▸ (`callback`): `void`
 
-Sets up a hook if the action fails. Return `false` to catch the error and
-stop it from propagating.
+Establece un hook si la acción falla. Retorna `false` para capturar el error y 
+evitar que se propague.
 
-##### Parameters
+##### Parámetros {#parameters-1}
 
-| Name | Type |
+| Nombre | Tipo |
 | :------ | :------ |
 | `callback` | (`error`: `unknown`) => `void` |
 
-##### Returns
+##### Retorna {#returns-1}
 
 `void`
 
 ___
 
-### store
+### store {#store}
 
 • **store**: `Store`
 
-Store that is invoking the action
+Almacén que está invocando la acción

--- a/api/interfaces/pinia._StoreWithState.md
+++ b/api/interfaces/pinia._StoreWithState.md
@@ -6,96 +6,96 @@ sidebarDepth: 3
 
 [Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / \_StoreWithState
 
-# Interface: \_StoreWithState<Id, S, G, A\>
+# Interfaz: \_StoreWithState<Id, S, G, A\> {#interface-storewithstate-id-s-g-a}
 
 [pinia](../modules/pinia.md)._StoreWithState
 
-Base store with state and functions. Should not be used directly.
+Almacén base con estado y funciones. No debe utilizarse directamente.
 
-## Type parameters
+## Tipado de los parámetros {#type-parameters}
 
-| Name | Type |
+| Nombre | Tipo |
 | :------ | :------ |
-| `Id` | extends `string` |
-| `S` | extends [`StateTree`](../modules/pinia.md#statetree) |
+| `Id` | extiende `string` |
+| `S` | extiende [`StateTree`](../modules/pinia.md#statetree) |
 | `G` | `G` |
 | `A` | `A` |
 
-## Hierarchy
+## Jerarquía {#hierarchy}
 
 - [`StoreProperties`](pinia.StoreProperties.md)<`Id`\>
 
   ↳ **`_StoreWithState`**
 
-## Properties
+## Propiedades {#properties}
 
-### $id
+### $id {#id}
 
 • **$id**: `Id`
 
-Unique identifier of the store
+Identificador único del almacén
 
-#### Inherited from
+#### Heredado de {#inherited-from}
 
 [StoreProperties](pinia.StoreProperties.md).[$id](pinia.StoreProperties.md#$id)
 
 ___
 
-### $state
+### $state {#state}
 
 • **$state**: `UnwrapRef`<`S`\> & [`PiniaCustomStateProperties`](pinia.PiniaCustomStateProperties.md)<`S`\>
 
-State of the Store. Setting it will replace the whole state.
+Estado del almacén. Establecerlo reemplazará todo el estado.
 
 ___
 
-### \_customProperties
+### \_customProperties {#customproperties}
 
 • **\_customProperties**: `Set`<`string`\>
 
-Used by devtools plugin to retrieve properties added with plugins. Removed
-in production. Can be used by the user to add property keys of the store
-that should be displayed in devtools.
+Usado por el plugin devtools para obtener propiedades añadidas con plugins. Eliminado
+en producción. Puede ser usado por el usuario para añadir claves de propiedades del almacén
+que deberían mostrarse en devtools.
 
-#### Inherited from
+#### Heredado de {#inherited-from-1}
 
 [StoreProperties](pinia.StoreProperties.md).[_customProperties](pinia.StoreProperties.md#_customproperties)
 
-## Methods
+## Methods {#methods}
 
-### $dispose
+### $dispose {#dispose}
 
 ▸ **$dispose**(): `void`
 
-Stops the associated effect scope of the store and remove it from the store
-registry. Plugins can override this method to cleanup any added effects.
-e.g. devtools plugin stops displaying disposed stores from devtools.
+Detiene el alcance del efecto asociado al almacén y lo elimina del registro.
+Los plugins pueden sobrescribir este método para limpiar cualquier efecto añadido.
+Por ejemplo, el plugin devtools deja de mostrar los almacenes desechados desde devtools.
 
-#### Returns
+#### Returns {#returns}
 
 `void`
 
 ___
 
-### $onAction
+### $onAction {#onaction}
 
 ▸ **$onAction**(`callback`, `detached?`): () => `void`
 
-Setups a callback to be called every time an action is about to get
-invoked. The callback receives an object with all the relevant information
-of the invoked action:
-- `store`: the store it is invoked on
-- `name`: The name of the action
-- `args`: The parameters passed to the action
+Establece un callback cada vez que una acción está a punto de ser 
+invocada. El callback recibe un objeto con toda la información relevante
+de la acción invocada:
+- `store`: el almacén sobre el que se invoca
+- `name`: El nombre de la acción
+- `args`: Los parámetros pasados a la acción
 
-On top of these, it receives two functions that allow setting up a callback
-once the action finishes or when it fails.
+Además de esto, recibe dos funciones que permiten establecer un callback
+una vez que la acción finaliza o cuando falla.
 
-It also returns a function to remove the callback. Note than when calling
-`store.$onAction()` inside of a component, it will be automatically cleaned
-up when the component gets unmounted unless `detached` is set to true.
+También devuelve una función para eliminar el callback. Ten en cuenta que al llamar a
+`store.$onAction()` dentro de un componente, se limpiará automáticamente
+cuando el componente sea desmontado a menos que `detached` sea true.
 
-**`Example`**
+**`Ejemplo`**
 
 ```js
 store.$onAction(({ after, onError }) => {
@@ -112,36 +112,36 @@ store.$onAction(({ after, onError }) => {
 })
 ```
 
-#### Parameters
+#### Parameters {#parameters}
 
-| Name | Type | Description |
+| Nombre | Tipo | Descripción |
 | :------ | :------ | :------ |
-| `callback` | [`StoreOnActionListener`](../modules/pinia.md#storeonactionlistener)<`Id`, `S`, `G`, `A`\> | callback called before every action |
-| `detached?` | `boolean` | detach the subscription from the context this is called from |
+| `callback` | [`StoreOnActionListener`](../modules/pinia.md#storeonactionlistener)<`Id`, `S`, `G`, `A`\> | callback llamado antes de cada acción |
+| `detached?` | `boolean` | desvincular la suscripción del contexto desde el que se llama a esta opción |
 
-#### Returns
+#### Returns {#returns-1}
 
 `fn`
 
-function that removes the watcher
+función que elimina el observador
 
 ▸ (): `void`
 
-Setups a callback to be called every time an action is about to get
-invoked. The callback receives an object with all the relevant information
-of the invoked action:
-- `store`: the store it is invoked on
-- `name`: The name of the action
-- `args`: The parameters passed to the action
+Establece un callback cada vez que una acción está a punto de ser 
+invocada. El callback recibe un objeto con toda la información relevante
+de la acción invocada:
+- `store`: el almacén sobre el que se invoca
+- `name`: El nombre de la acción
+- `args`: Los parámetros pasados a la acción
 
-On top of these, it receives two functions that allow setting up a callback
-once the action finishes or when it fails.
+Además de esto, recibe dos funciones que permiten establecer un callback
+una vez que la acción finaliza o cuando falla.
 
-It also returns a function to remove the callback. Note than when calling
-`store.$onAction()` inside of a component, it will be automatically cleaned
-up when the component gets unmounted unless `detached` is set to true.
+También devuelve una función para eliminar el callback. Ten en cuenta que al llamar a
+`store.$onAction()` dentro de un componente, se limpiará automáticamente
+cuando el componente sea desmontado a menos que `detached` sea true.
 
-**`Example`**
+**`Ejemplo`**
 
 ```js
 store.$onAction(({ after, onError }) => {
@@ -158,96 +158,96 @@ store.$onAction(({ after, onError }) => {
 })
 ```
 
-##### Returns
+##### Retorna {#returns-2}
 
 `void`
 
-function that removes the watcher
+función que elimina el observador
 
 ___
 
-### $patch
+### $patch {#patch}
 
 ▸ **$patch**(`partialState`): `void`
 
-Applies a state patch to current state. Allows passing nested values
+Aplica un patch de estado al estado actual. Permite pasar valores anidados
 
-#### Parameters
+#### Parámetros {#parameters-1} 
 
-| Name | Type | Description |
+| Nombre | Tipo | Descripción |
 | :------ | :------ | :------ |
-| `partialState` | [`_DeepPartial`](../modules/pinia.md#_deeppartial)<`UnwrapRef`<`S`\>\> | patch to apply to the state |
+| `partialState` | [`_DeepPartial`](../modules/pinia.md#_deeppartial)<`UnwrapRef`<`S`\>\> | patch para aplicar al estado |
 
-#### Returns
+#### Retorna {#returns-3}
 
 `void`
 
 ▸ **$patch**<`F`\>(`stateMutator`): `void`
 
-Group multiple changes into one function. Useful when mutating objects like
-Sets or arrays and applying an object patch isn't practical, e.g. appending
-to an array. The function passed to `$patch()` **must be synchronous**.
+Agrupa múltiples cambios en una función. Útil cuando se mutan objetos como 
+Sets o arrays y aplicar un patch a un objeto no es práctico, por ejemplo, añadir 
+a un array. La función pasada a `$patch()` **debe ser síncrona**.
 
-#### Type parameters
+#### Tipado de los parámetros {#type-parameters-1}
 
-| Name | Type |
+| Nombre | Tipo |
 | :------ | :------ |
-| `F` | extends (`state`: `UnwrapRef`<`S`\>) => `any` |
+| `F` | extiende (`state`: `UnwrapRef`<`S`\>) => `any` |
 
-#### Parameters
+#### Parámetros {#parameters-2}
 
-| Name | Type | Description |
+| Nombre | Tipo | Descripción |
 | :------ | :------ | :------ |
-| `stateMutator` | `ReturnType`<`F`\> extends `Promise`<`any`\> ? `never` : `F` | function that mutates `state`, cannot be async |
+| `stateMutator` | `ReturnType`<`F`\> extiende `Promise`<`any`\> ? `never` : `F` | función que muta `state`, no puede ser async |
 
-#### Returns
+#### Retorna {#returns-4}
 
 `void`
 
 ___
 
-### $reset
+### $reset {#reset}
 
 ▸ **$reset**(): `void`
 
-Resets the store to its initial state by building a new state object.
-TODO: make this options only
+Reinicia el almacén a su estado inicial mediante la construcción de un nuevo objeto de estado.
+TODO: hacer esto solo para almacenes de opciones
 
-#### Returns
+#### Retorna {#returns-5}
 
 `void`
 
 ___
 
-### $subscribe
+### $subscribe {#subscribe}
 
 ▸ **$subscribe**(`callback`, `options?`): () => `void`
 
-Setups a callback to be called whenever the state changes. It also returns a function to remove the callback. Note
-that when calling `store.$subscribe()` inside of a component, it will be automatically cleaned up when the
-component gets unmounted unless `detached` is set to true.
+Establece un callback que se llamará cada vez que cambie el estado. También devuelve una función para eliminar el callback. Ten en cuenta
+que cuando se llama a `store.$subscribe()` dentro de un componente, se limpiará automáticamente cuando el 
+componente se desmonte a menos que `detached` sea true.
 
-#### Parameters
+#### Parámetros {#parameters-3}
 
-| Name | Type | Description |
+| Nombre | Tipo | Descripción |
 | :------ | :------ | :------ |
-| `callback` | [`SubscriptionCallback`](../modules/pinia.md#subscriptioncallback)<`S`\> | callback passed to the watcher |
-| `options?` | { `detached?`: `boolean`  } & `WatchOptions`<`boolean`\> | `watch` options + `detached` to detach the subscription from the context (usually a component) this is called from. Note that the `flush` option does not affect calls to `store.$patch()`. |
+| `callback` | [`SubscriptionCallback`](../modules/pinia.md#subscriptioncallback)<`S`\> | callback pasado al observador |
+| `options?` | { `detached?`: `boolean`  } & `WatchOptions`<`boolean`\> | opciones de `watch` + `detached` para desvincular la suscripción del contexto (normalmente un componente) desde el que se llama. Ten en cuenta que la opción `flush` no afecta a las llamadas a `store.$patch()`. |
 
-#### Returns
+#### Retorna {#returns-6}
 
 `fn`
 
-function that removes the watcher
+función que elimina el observador
 
 ▸ (): `void`
 
-Setups a callback to be called whenever the state changes. It also returns a function to remove the callback. Note
-that when calling `store.$subscribe()` inside of a component, it will be automatically cleaned up when the
-component gets unmounted unless `detached` is set to true.
+Establece un callback que se llamará cada vez que cambie el estado. También devuelve una función para eliminar el callback. Ten en cuenta
+que cuando se llama a `store.$subscribe()` dentro de un componente, se limpiará automáticamente cuando el 
+componente se desmonte a menos que `detached` sea true.
 
-##### Returns
+##### Retorna {#returns-7}
 
 `void`
 
-function that removes the watcher
+función que elimina el observador

--- a/api/interfaces/pinia._SubscriptionCallbackMutationBase.md
+++ b/api/interfaces/pinia._SubscriptionCallbackMutationBase.md
@@ -28,7 +28,7 @@ Tipo base para el contexto pasado a un callback de suscripción. Tipo interno.
 
 • `Optional` **events**: `DebuggerEvent` \| `DebuggerEvent`[]
 
-🔴 DEV SOLAMENTE, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
+🔴 SOLO PARA DESARROLLO, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
 https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging y permite realizar un rastreo de mutaciones en
 devtools y plugins **sólo durante el desarrollo**.
 ___

--- a/api/interfaces/pinia._SubscriptionCallbackMutationBase.md
+++ b/api/interfaces/pinia._SubscriptionCallbackMutationBase.md
@@ -6,13 +6,13 @@ sidebarDepth: 3
 
 [Documentación de la API](../index.md) / [pinia](../modules/pinia.md) / \_SubscriptionCallbackMutationBase
 
-# Interface: \_SubscriptionCallbackMutationBase
+# Interfaz: \_SubscriptionCallbackMutationBase {#interfaz-subscriptioncallbackmutationbase}
 
 [pinia](../modules/pinia.md)._SubscriptionCallbackMutationBase
 
-Base type for the context passed to a subscription callback. Internal type.
+Tipo base para el contexto pasado a un callback de suscripción. Tipo interno.
 
-## Hierarchy
+## Jerarquía {#hierarchy}
 
 - **`_SubscriptionCallbackMutationBase`**
 
@@ -22,28 +22,27 @@ Base type for the context passed to a subscription callback. Internal type.
 
   ↳ [`SubscriptionCallbackMutationPatchObject`](pinia.SubscriptionCallbackMutationPatchObject.md)
 
-## Properties
+## Propiedades {#properties}
 
-### events
+### events {#events}
 
 • `Optional` **events**: `DebuggerEvent` \| `DebuggerEvent`[]
 
-🔴 DEV ONLY, DO NOT use for production code. Different mutation calls. Comes from
-https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging and allows to track mutations in
-devtools and plugins **during development only**.
-
+🔴 DEV SOLAMENTE, NO usar para código de producción. Diferentes llamadas de mutación. Viene de
+https://vuejs.org/guide/extras/reactivity-in-depth.html#reactivity-debugging y permite realizar un rastreo de mutaciones en
+devtools y plugins **sólo durante el desarrollo**.
 ___
 
-### storeId
+### storeId {#storeid}
 
 • **storeId**: `string`
 
-`id` of the store doing the mutation.
+`id` del almacén que realiza la mutación.
 
 ___
 
-### type
+### type {#type}
 
 • **type**: [`MutationType`](../enums/pinia.MutationType.md)
 
-Type of the mutation.
+Tipo de mutación.


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Feature :sparkles:
- [ ] Code style update (formatting, renaming) :art:
- [ ] Refactoring (no functional changes, no api changes) :recycle:
- [x] Documentation content changes :memo:
- [ ] Other :zap:

## What is the new behavior?

_Translate the following files:_

- `pinia._StoreOnActionListenerContext.md`
- `pinia._StoreWithState.md`
- `pinia._SubscriptionCallbackMutationBase.md`
- `pinia.SubscriptionCallbackMutationDirect.md`
- `pinia.SubscriptionCallbackMutationPatchFunction.md`
- `pinia.SubscriptionCallbackMutationPatchObject.md`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
